### PR TITLE
chatspace自動更新機能実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -68,30 +68,21 @@ $(function(){
     })
   })
   var reloadMessages = function() {
-    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
     last_message_id = $('.message:last').data("message-id");
     $.ajax({
-      //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
       url: "api/messages",
-      //ルーティングで設定した通りhttpメソッドをgetに指定
       type: 'get',
       dataType: 'json',
-      //dataオプションでリクエストに値を含める
       data: {id: last_message_id}
     })
     .done(function(messages) {
       if (messages.length !== 0) {
-        //追加するHTMLの入れ物を作る
         var insertHTML = '';
-        //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
         $.each(messages, function(i, message) {
           insertHTML = buildHTML(message)
         });
-        //メッセージが入ったHTMLに、入れ物ごと追加
         $('.messages').append(insertHTML);
         $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
-        // $("#new_message")[0].reset();
-        // $(".form__submit").prop("disabled", false);
       }
     })
     .fail(function() {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,6 @@
 $(function(){ 
+  last_message_id = $('.message:last').data("message-id");
+  console.log(last_message_id);
   function buildHTML(message){
    if ( message.image ) {
      var html =
@@ -38,31 +40,67 @@ $(function(){
        </div>`
      return html;
    };
- }
-$('#new_message').on('submit', function(e){
- e.preventDefault();
- var formData = new FormData(this);
- var url = $(this).attr('action')
- $.ajax({
-   url: url,
-   type: "POST",
-   data: formData,
-   dataType: 'json',
-   processData: false,
-   contentType: false
- })
-  .done(function(data){  
-    var html = buildHTML(data);
-    $('.messages').append(html);      
-    $('form')[0].reset();
-    $(".form__submit").removeAttr("disabled");
-    $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
-  })  
-  .fail(function() {
-    alert("メッセージ送信に失敗しました");
-  })  
-  .always(function(){
-    $(".form__submit").removeAttr("disabled");
+  }
+  $('#new_message').on('submit', function(e){
+  e.preventDefault();
+  var formData = new FormData(this);
+  var url = $(this).attr('action')
+  $.ajax({
+    url: url,
+    type: "POST",
+    data: formData,
+    dataType: 'json',
+    processData: false,
+    contentType: false
   })
-})
+    .done(function(data){  
+      var html = buildHTML(data);
+      $('.messages').append(html);      
+      $('form')[0].reset();
+      $(".form__submit").removeAttr("disabled");
+      $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+    })  
+    .fail(function() {
+      alert("メッセージ送信に失敗しました");
+    })  
+    .always(function(){
+      $(".form__submit").removeAttr("disabled");
+    })
+  })
+  var reloadMessages = function() {
+    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+    last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+      url: "api/messages",
+      //ルーティングで設定した通りhttpメソッドをgetに指定
+      type: 'get',
+      dataType: 'json',
+      //dataオプションでリクエストに値を含める
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        //追加するHTMLの入れ物を作る
+        var insertHTML = '';
+        //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        //メッセージが入ったHTMLに、入れ物ごと追加
+        $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+        $("#new_message")[0].reset();
+        $(".form__submit").prop("disabled", false);
+      }
+    })
+    .fail(function() {
+      console.log('error');
+    });
+  };
+  setInterval(reloadMessages, 7000);
+
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,6 @@
 $(function(){ 
   last_message_id = $('.message:last').data("message-id");
-  console.log(last_message_id);
+  
   function buildHTML(message){
    if ( message.image ) {
      var html =
@@ -85,21 +85,19 @@ $(function(){
         var insertHTML = '';
         //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
         $.each(messages, function(i, message) {
-          insertHTML += buildHTML(message)
+          insertHTML = buildHTML(message)
         });
         //メッセージが入ったHTMLに、入れ物ごと追加
         $('.messages').append(insertHTML);
         $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
-        $("#new_message")[0].reset();
-        $(".form__submit").prop("disabled", false);
+        // $("#new_message")[0].reset();
+        // $(".form__submit").prop("disabled", false);
       }
     })
     .fail(function() {
-      console.log('error');
+      alert('error');
     });
   };
-  setInterval(reloadMessages, 7000);
-
   if (document.location.href.match(/\/groups\/\d+\/messages/)) {
     setInterval(reloadMessages, 7000);
   }

--- a/app/assets/stylesheets/modules/chat.scss
+++ b/app/assets/stylesheets/modules/chat.scss
@@ -39,10 +39,12 @@
     }
 
     .messages {
+      overflow: auto;
       background-color: #FAFAFA;
       box-sizing: border-box;
       padding: 46px 40px 0;
-      height: calc(100% - 100px - 90px);
+      height: calc(100vh - 100px - 90px);
+      width: 100%;
       .message {
         .upper-message {
           display: flex;

--- a/app/assets/stylesheets/modules/side_bar.scss
+++ b/app/assets/stylesheets/modules/side_bar.scss
@@ -26,6 +26,7 @@
   }
 
   .groups {
+    overflow: auto;
     background-color: $side_blue_light;
     height: calc(100vh - 100px);
     padding: 0 20px;

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,11 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -21,7 +21,22 @@
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
+    
       #chat-group-users.js-add-user
+        .chat-group-user.clearfix.js-chat-member
+          %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
+          %p.chat-group-user__name= current_user.name
+
+        - group.users.each do |user|
+          - if current_user.name != user.name
+            .chat-group-user.clearfix.js-chat-member
+              %input{name: "group[user_ids][]", type: "hidden", value: user.id}
+              %p.chat-group-user__name
+                = user.name 
+              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn
+                削除
+
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,6 @@
-json.user_name @message.user.name
+json.content    @message.content
+json.image      @message.image.url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-json.content @message.content
-json.image @message.image
+json.user_name @message.user.name
+#idもデータとして渡す
+json.id @message.id

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -3,8 +3,6 @@
   = render 'shared/side_bar'
 
   
-
-
   .chat
     .header
       .left-header

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end  
   end
 end

--- a/log/development.log
+++ b/log/development.log
@@ -11215,3 +11215,8393 @@ Processing by Api::MessagesController#index as JSON
 Completed 200 OK in 31ms (Views: 15.3ms | ActiveRecord: 10.1ms)
 
 
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:00 +0900
+  [1m[36mActiveRecord::SchemaMigration Load (0.4ms)[0m  [1m[34mSELECT `schema_migrations`.* FROM `schema_migrations`[0m
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (3.5ms)
+Completed 200 OK in 216ms (Views: 30.7ms | ActiveRecord: 17.5ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:00 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (36.6ms)
+Completed 200 OK in 84ms (Views: 64.2ms | ActiveRecord: 2.6ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:01 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (6.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (2.1ms)
+Completed 200 OK in 33ms (Views: 20.6ms | ActiveRecord: 8.1ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:01 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (1.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 24ms (Views: 15.1ms | ActiveRecord: 2.3ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:07 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (4.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (11.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (15.1ms)
+Completed 200 OK in 40ms (Views: 17.3ms | ActiveRecord: 17.5ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:07 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (14.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (16.3ms)
+Completed 200 OK in 36ms (Views: 15.3ms | ActiveRecord: 15.7ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:07 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (1.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (1.8ms)
+Completed 200 OK in 26ms (Views: 13.9ms | ActiveRecord: 4.3ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:07 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (11.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (12.4ms)
+Completed 200 OK in 36ms (Views: 18.1ms | ActiveRecord: 11.9ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 17:24:09 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (2.2ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (4.7ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (58.7ms)
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [6 times] (7.2ms)
+  Rendered messages/_main_chat.html.haml (35.7ms)
+  Rendered messages/index.html.haml within layouts/application (125.3ms)
+  Rendered layouts/_notifications.html.haml (18.2ms)
+Completed 200 OK in 1148ms (Views: 1121.7ms | ActiveRecord: 13.0ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 17:24:12 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (11.4ms)
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [6 times] (9.4ms)
+  Rendered messages/_main_chat.html.haml (27.0ms)
+  Rendered messages/index.html.haml within layouts/application (48.5ms)
+  Rendered layouts/_notifications.html.haml (3.6ms)
+Completed 200 OK in 177ms (Views: 166.7ms | ActiveRecord: 2.4ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 17:24:12 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (1.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (1.4ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (13.3ms)
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (6.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [6 times] (4.6ms)
+  Rendered messages/_main_chat.html.haml (19.2ms)
+  Rendered messages/index.html.haml within layouts/application (41.7ms)
+  Rendered layouts/_notifications.html.haml (4.7ms)
+Completed 200 OK in 123ms (Views: 105.9ms | ActiveRecord: 11.1ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:17 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (6.5ms)
+Completed 200 OK in 25ms (Views: 14.5ms | ActiveRecord: 5.6ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:17 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (16.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (18.1ms)
+Completed 200 OK in 41ms (Views: 15.0ms | ActiveRecord: 18.2ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:20 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (52.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (54.1ms)
+Completed 200 OK in 79ms (Views: 14.5ms | ActiveRecord: 57.7ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:20 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (7.0ms)
+Completed 200 OK in 38ms (Views: 24.1ms | ActiveRecord: 6.6ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:24 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (2.6ms)
+Completed 200 OK in 22ms (Views: 16.7ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:24 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (2.5ms)
+Completed 200 OK in 25ms (Views: 18.2ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:27 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (1.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (6.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (5.3ms)
+Completed 200 OK in 52ms (Views: 32.0ms | ActiveRecord: 12.3ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:27 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (5.7ms)
+Completed 200 OK in 40ms (Views: 21.2ms | ActiveRecord: 9.6ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:31 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (3.3ms)
+Completed 200 OK in 21ms (Views: 14.9ms | ActiveRecord: 3.1ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:31 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (3.0ms)
+Completed 200 OK in 18ms (Views: 11.2ms | ActiveRecord: 2.5ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:34 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (2.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (3.6ms)
+Completed 200 OK in 27ms (Views: 16.8ms | ActiveRecord: 4.8ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:34 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 18ms (Views: 12.5ms | ActiveRecord: 1.6ms)
+
+
+Started POST "/groups/17/messages" for ::1 at 2020-01-16 17:24:36 +0900
+Processing by MessagesController#create as JSON
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"BAA5E8F8+8pfxeaDN11noZaI4Ikc/ByUHzmIS1e+Z47/n+H/y4o97Wm7PeJYGdsvz5u4ZrCo/JoqMa8HILdG+A==", "message"=>{"content"=>"test"}, "group_id"=>"17"}
+  [1m[36mUser Load (2.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  [1m[35m (8.9ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 LIMIT 1[0m
+  [1m[35mSQL (2.0ms)[0m  [1m[32mINSERT INTO `messages` (`content`, `group_id`, `user_id`, `created_at`, `updated_at`) VALUES ('test', 17, 8, '2020-01-16 08:24:36', '2020-01-16 08:24:36')[0m
+  [1m[35m (1.1ms)[0m  [1m[35mCOMMIT[0m
+  Rendering messages/create.json.jbuilder
+  Rendered messages/create.json.jbuilder (1.2ms)
+Completed 200 OK in 46ms (Views: 14.8ms | ActiveRecord: 17.8ms)
+
+
+Started GET "/groups/17/api/messages?id=54" for ::1 at 2020-01-16 17:24:38 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"54", "group_id"=>"17"}
+  [1m[36mUser Load (1.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 54)[0m
+  Rendered api/messages/index.json.jbuilder (2.1ms)
+Completed 200 OK in 25ms (Views: 16.3ms | ActiveRecord: 2.9ms)
+
+
+Started GET "/groups/17/api/messages?id=54" for ::1 at 2020-01-16 17:24:38 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"54", "group_id"=>"17"}
+  [1m[36mUser Load (1.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 54)[0m
+  Rendered api/messages/index.json.jbuilder (5.0ms)
+Completed 200 OK in 25ms (Views: 16.6ms | ActiveRecord: 4.9ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:41 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (3.9ms)
+Completed 200 OK in 23ms (Views: 17.4ms | ActiveRecord: 1.5ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 17:24:41 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (3.6ms)
+Completed 200 OK in 35ms (Views: 16.5ms | ActiveRecord: 8.8ms)
+
+
+Started GET "/groups/17/api/messages?id=54" for ::1 at 2020-01-16 17:24:45 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"54", "group_id"=>"17"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 54)[0m
+  Rendered api/messages/index.json.jbuilder (5.4ms)
+Completed 200 OK in 24ms (Views: 16.5ms | ActiveRecord: 3.3ms)
+
+
+Started GET "/groups/17/api/messages?id=54" for ::1 at 2020-01-16 17:24:45 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"54", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (7.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 54)[0m
+  Rendered api/messages/index.json.jbuilder (8.5ms)
+Completed 200 OK in 31ms (Views: 17.8ms | ActiveRecord: 8.4ms)
+
+
+Started GET "/groups/17/api/messages?id=54" for ::1 at 2020-01-16 17:24:48 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"54", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 54)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 23ms (Views: 14.1ms | ActiveRecord: 1.8ms)
+
+
+Started GET "/groups/17/api/messages?id=54" for ::1 at 2020-01-16 17:24:48 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"54", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 54)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 28ms (Views: 19.7ms | ActiveRecord: 3.4ms)
+
+
+Started GET "/groups/17/api/messages?id=54" for ::1 at 2020-01-16 17:24:52 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"54", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 54)[0m
+  Rendered api/messages/index.json.jbuilder (8.9ms)
+Completed 200 OK in 29ms (Views: 15.8ms | ActiveRecord: 7.4ms)
+
+
+Started GET "/groups/17/api/messages?id=54" for ::1 at 2020-01-16 17:24:52 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"54", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 54)[0m
+  Rendered api/messages/index.json.jbuilder (2.1ms)
+Completed 200 OK in 23ms (Views: 16.1ms | ActiveRecord: 1.5ms)
+
+
+Started GET "/groups/17/api/messages?id=54" for ::1 at 2020-01-16 17:24:55 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"54", "group_id"=>"17"}
+  [1m[36mUser Load (10.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 54)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 41ms (Views: 25.8ms | ActiveRecord: 10.7ms)
+
+
+Started GET "/groups/17/api/messages?id=54" for ::1 at 2020-01-16 17:24:55 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"54", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 54)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 29ms (Views: 22.7ms | ActiveRecord: 1.6ms)
+
+
+Started POST "/groups/17/messages" for ::1 at 2020-01-16 17:24:57 +0900
+Processing by MessagesController#create as JSON
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"BAA5E8F8+8pfxeaDN11noZaI4Ikc/ByUHzmIS1e+Z47/n+H/y4o97Wm7PeJYGdsvz5u4ZrCo/JoqMa8HILdG+A==", "message"=>{"content"=>"aaa"}, "group_id"=>"17"}
+  [1m[36mUser Load (4.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (14.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  [1m[35m (14.9ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 LIMIT 1[0m
+  [1m[35mSQL (1.6ms)[0m  [1m[32mINSERT INTO `messages` (`content`, `group_id`, `user_id`, `created_at`, `updated_at`) VALUES ('aaa', 17, 8, '2020-01-16 08:24:57', '2020-01-16 08:24:57')[0m
+  [1m[35m (1.1ms)[0m  [1m[35mCOMMIT[0m
+  Rendering messages/create.json.jbuilder
+  Rendered messages/create.json.jbuilder (0.8ms)
+Completed 200 OK in 67ms (Views: 20.1ms | ActiveRecord: 36.9ms)
+
+
+Started POST "/groups/17/messages" for ::1 at 2020-01-16 17:24:58 +0900
+Processing by MessagesController#create as JSON
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"BAA5E8F8+8pfxeaDN11noZaI4Ikc/ByUHzmIS1e+Z47/n+H/y4o97Wm7PeJYGdsvz5u4ZrCo/JoqMa8HILdG+A==", "message"=>{"content"=>""}, "group_id"=>"17"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 LIMIT 1[0m
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:24:59 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (49.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (9.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (10.5ms)
+Completed 200 OK in 83ms (Views: 15.3ms | ActiveRecord: 59.7ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:24:59 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (8.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (6.0ms)
+Completed 200 OK in 37ms (Views: 17.2ms | ActiveRecord: 15.1ms)
+
+
+  [1m[35m (2.3ms)[0m  [1m[31mROLLBACK[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (18.1ms)
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [8 times] (8.4ms)
+  Rendered messages/_main_chat.html.haml (50.0ms)
+  Rendered messages/index.html.haml within layouts/application (139.9ms)
+  Rendered layouts/_notifications.html.haml (4.2ms)
+Completed 200 OK in 2842ms (Views: 285.7ms | ActiveRecord: 9.0ms)
+
+
+Started GET "/groups/17/api/messages?id=54" for ::1 at 2020-01-16 17:25:02 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"54", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 54)[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (8.6ms)
+Completed 200 OK in 32ms (Views: 21.2ms | ActiveRecord: 6.9ms)
+
+
+Started GET "/groups/17/api/messages?id=54" for ::1 at 2020-01-16 17:25:02 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"54", "group_id"=>"17"}
+  [1m[36mUser Load (6.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 54)[0m
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (9.0ms)
+Completed 200 OK in 36ms (Views: 18.2ms | ActiveRecord: 12.1ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:06 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (3.1ms)
+Completed 200 OK in 24ms (Views: 16.3ms | ActiveRecord: 3.3ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:06 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (7.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (9.0ms)
+Completed 200 OK in 30ms (Views: 16.3ms | ActiveRecord: 8.2ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (3.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (14.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (15.8ms)
+Completed 200 OK in 40ms (Views: 15.0ms | ActiveRecord: 18.8ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (4.4ms)
+Completed 200 OK in 24ms (Views: 14.9ms | ActiveRecord: 4.9ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:14 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (15.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (46.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (64.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (65.3ms)
+Completed 200 OK in 170ms (Views: 37.8ms | ActiveRecord: 125.5ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:14 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (14.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (25.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (29.5ms)
+Completed 200 OK in 86ms (Views: 29.7ms | ActiveRecord: 44.9ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:16 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (15.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (17.3ms)
+Completed 200 OK in 41ms (Views: 17.7ms | ActiveRecord: 16.8ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:16 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (32.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (12.4ms)
+Completed 200 OK in 67ms (Views: 27.8ms | ActiveRecord: 34.2ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:20 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (11.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (12.3ms)
+Completed 200 OK in 80ms (Views: 59.2ms | ActiveRecord: 16.1ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:20 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (7.5ms)
+Completed 200 OK in 33ms (Views: 18.4ms | ActiveRecord: 7.4ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:24 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (6.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 33ms (Views: 20.7ms | ActiveRecord: 7.1ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:24 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (10.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (16.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (17.4ms)
+Completed 200 OK in 53ms (Views: 20.2ms | ActiveRecord: 27.5ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:28 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (9.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 30ms (Views: 14.4ms | ActiveRecord: 10.2ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:28 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (28.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (33.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (34.8ms)
+Completed 200 OK in 106ms (Views: 35.1ms | ActiveRecord: 62.2ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:30 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (5.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (16.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (19.2ms)
+Completed 200 OK in 49ms (Views: 15.6ms | ActiveRecord: 25.4ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:30 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 39ms (Views: 27.3ms | ActiveRecord: 1.4ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:35 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (18.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (44.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (45.7ms)
+Completed 200 OK in 91ms (Views: 21.7ms | ActiveRecord: 63.1ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:35 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (27.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 65ms (Views: 19.3ms | ActiveRecord: 28.4ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:37 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 22ms (Views: 15.8ms | ActiveRecord: 1.4ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:37 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (19.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (20.0ms)
+Completed 200 OK in 41ms (Views: 16.0ms | ActiveRecord: 19.7ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:41 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (8.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (13.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (59.3ms)
+Completed 200 OK in 99ms (Views: 71.1ms | ActiveRecord: 22.2ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:41 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (22.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (31.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (36.2ms)
+Completed 200 OK in 160ms (Views: 97.1ms | ActiveRecord: 54.9ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:44 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (13.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (14.7ms)
+Completed 200 OK in 46ms (Views: 26.0ms | ActiveRecord: 14.2ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:44 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (9.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (72.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (75.2ms)
+Completed 200 OK in 147ms (Views: 29.4ms | ActiveRecord: 82.3ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:49 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (25.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (11.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (22.0ms)
+Completed 200 OK in 91ms (Views: 43.1ms | ActiveRecord: 37.6ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:49 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 52ms (Views: 34.2ms | ActiveRecord: 1.7ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:52 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (12.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (18.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (20.2ms)
+Completed 200 OK in 59ms (Views: 19.5ms | ActiveRecord: 32.9ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:52 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (26.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (7.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (9.1ms)
+Completed 200 OK in 64ms (Views: 23.1ms | ActiveRecord: 35.5ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:56 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (23.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (9.5ms)
+Completed 200 OK in 60ms (Views: 24.4ms | ActiveRecord: 30.3ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:56 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 25ms (Views: 15.2ms | ActiveRecord: 4.5ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:58 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (3.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (41.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (42.3ms)
+Completed 200 OK in 69ms (Views: 19.3ms | ActiveRecord: 45.1ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:25:58 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (27.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 74ms (Views: 33.0ms | ActiveRecord: 28.4ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:03 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (9.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (3.1ms)
+Completed 200 OK in 38ms (Views: 16.3ms | ActiveRecord: 14.1ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:03 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (7.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (2.9ms)
+Completed 200 OK in 104ms (Views: 90.5ms | ActiveRecord: 8.8ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:05 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (9.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (15.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (16.7ms)
+Completed 200 OK in 61ms (Views: 29.5ms | ActiveRecord: 26.5ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:05 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (13.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 69ms (Views: 39.3ms | ActiveRecord: 15.8ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (18.7ms)
+Completed 200 OK in 43ms (Views: 30.9ms | ActiveRecord: 5.8ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 33ms (Views: 18.6ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:12 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (8.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 38ms (Views: 21.0ms | ActiveRecord: 9.5ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:12 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (1.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (2.4ms)
+Completed 200 OK in 34ms (Views: 23.2ms | ActiveRecord: 4.4ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:16 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (7.0ms)
+Completed 200 OK in 34ms (Views: 22.7ms | ActiveRecord: 7.4ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:16 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (8.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (9.6ms)
+Completed 200 OK in 32ms (Views: 18.5ms | ActiveRecord: 9.3ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:20 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (6.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (8.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (10.0ms)
+Completed 200 OK in 57ms (Views: 36.2ms | ActiveRecord: 14.9ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:20 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (2.5ms)
+Completed 200 OK in 31ms (Views: 22.2ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:24 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (1.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 58ms (Views: 43.1ms | ActiveRecord: 9.2ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:24 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (3.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (10.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 88ms (Views: 17.0ms | ActiveRecord: 14.3ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:26 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (10.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (32.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (27.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (28.9ms)
+Completed 200 OK in 98ms (Views: 21.7ms | ActiveRecord: 69.5ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:26 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (5.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 67ms (Views: 45.9ms | ActiveRecord: 13.0ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:31 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (1.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (12.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (13.5ms)
+Completed 200 OK in 40ms (Views: 18.2ms | ActiveRecord: 14.1ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:31 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (14.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (9.9ms)
+Completed 200 OK in 86ms (Views: 54.9ms | ActiveRecord: 23.3ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:34 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (12.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (29.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (79.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (80.0ms)
+Completed 200 OK in 157ms (Views: 28.5ms | ActiveRecord: 120.7ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:35 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 41ms (Views: 31.2ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:37 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (21.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (17.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (19.6ms)
+Completed 200 OK in 70ms (Views: 18.8ms | ActiveRecord: 41.8ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:37 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (9.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (36.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (37.8ms)
+Completed 200 OK in 82ms (Views: 32.6ms | ActiveRecord: 46.1ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:41 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (9.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 44ms (Views: 24.0ms | ActiveRecord: 12.1ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:41 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (14.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (3.0ms)
+Completed 200 OK in 47ms (Views: 24.9ms | ActiveRecord: 15.2ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:45 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (17.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (32.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (35.1ms)
+Completed 200 OK in 75ms (Views: 19.9ms | ActiveRecord: 49.9ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:45 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (57.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (15.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (21.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (24.8ms)
+Completed 200 OK in 144ms (Views: 42.5ms | ActiveRecord: 94.9ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:47 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (2.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (25.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (55.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (56.6ms)
+Completed 200 OK in 115ms (Views: 23.5ms | ActiveRecord: 83.5ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:47 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (4.7ms)
+Completed 200 OK in 83ms (Views: 39.2ms | ActiveRecord: 2.0ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:52 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (27.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (39.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (40.8ms)
+Completed 200 OK in 99ms (Views: 27.6ms | ActiveRecord: 67.7ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:52 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (5.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (9.2ms)
+Completed 200 OK in 43ms (Views: 25.6ms | ActiveRecord: 12.7ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:54 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (8.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (3.4ms)
+Completed 200 OK in 37ms (Views: 21.5ms | ActiveRecord: 10.5ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:54 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (9.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (11.0ms)
+Completed 200 OK in 37ms (Views: 15.3ms | ActiveRecord: 11.0ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:59 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (5.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (11.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (13.1ms)
+Completed 200 OK in 47ms (Views: 24.6ms | ActiveRecord: 17.2ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:26:59 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (2.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (2.5ms)
+Completed 200 OK in 60ms (Views: 38.4ms | ActiveRecord: 4.2ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:27:02 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (16.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (2.0ms)
+Completed 200 OK in 56ms (Views: 29.6ms | ActiveRecord: 18.5ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:27:02 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (17.4ms)
+Completed 200 OK in 53ms (Views: 40.0ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:27:05 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (19.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (29.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (2.7ms)
+Completed 200 OK in 94ms (Views: 39.2ms | ActiveRecord: 48.7ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:27:05 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (5.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 69ms (Views: 57.7ms | ActiveRecord: 6.1ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:27:08 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (8.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (2.8ms)
+Completed 200 OK in 42ms (Views: 19.5ms | ActiveRecord: 10.8ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:27:08 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (10.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (5.0ms)
+Completed 200 OK in 45ms (Views: 24.6ms | ActiveRecord: 14.6ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:27:12 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (2.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (10.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (7.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (10.6ms)
+Completed 200 OK in 40ms (Views: 14.0ms | ActiveRecord: 20.3ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:27:12 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (11.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (2.1ms)
+Completed 200 OK in 40ms (Views: 21.3ms | ActiveRecord: 13.4ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:27:15 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (1.8ms)
+Completed 200 OK in 26ms (Views: 15.4ms | ActiveRecord: 1.8ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:27:15 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (1.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (14.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (2.0ms)
+Completed 200 OK in 40ms (Views: 17.5ms | ActiveRecord: 16.6ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 17:27:15 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (11.1ms)
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (1.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (1.6ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [8 times] (6.6ms)
+  Rendered messages/_main_chat.html.haml (21.0ms)
+  Rendered messages/index.html.haml within layouts/application (43.9ms)
+  Rendered layouts/_notifications.html.haml (3.1ms)
+Completed 200 OK in 238ms (Views: 227.0ms | ActiveRecord: 5.5ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 17:27:18 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (13.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (11.9ms)
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (2.6ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [8 times] (15.5ms)
+  Rendered messages/_main_chat.html.haml (24.2ms)
+  Rendered messages/index.html.haml within layouts/application (46.2ms)
+  Rendered layouts/_notifications.html.haml (3.5ms)
+Completed 200 OK in 125ms (Views: 98.8ms | ActiveRecord: 18.1ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 17:27:19 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (4.5ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (11.9ms)
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [8 times] (7.8ms)
+  Rendered messages/_main_chat.html.haml (22.9ms)
+  Rendered messages/index.html.haml within layouts/application (43.3ms)
+  Rendered layouts/_notifications.html.haml (5.0ms)
+Completed 200 OK in 119ms (Views: 103.6ms | ActiveRecord: 7.2ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 17:27:21 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (1.0ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (5.2ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (18.5ms)
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [8 times] (6.2ms)
+  Rendered messages/_main_chat.html.haml (18.0ms)
+  Rendered messages/index.html.haml within layouts/application (46.5ms)
+  Rendered layouts/_notifications.html.haml (4.8ms)
+Completed 200 OK in 102ms (Views: 88.8ms | ActiveRecord: 8.7ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 17:27:21 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (1.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (13.3ms)
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [8 times] (14.7ms)
+  Rendered messages/_main_chat.html.haml (30.4ms)
+  Rendered messages/index.html.haml within layouts/application (60.2ms)
+  Rendered layouts/_notifications.html.haml (4.4ms)
+Completed 200 OK in 120ms (Views: 107.5ms | ActiveRecord: 7.4ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:27:26 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (2.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (2.6ms)
+Completed 200 OK in 33ms (Views: 17.2ms | ActiveRecord: 6.3ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:27:26 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (6.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (9.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (10.3ms)
+Completed 200 OK in 39ms (Views: 14.7ms | ActiveRecord: 18.1ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:27:29 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (6.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 32ms (Views: 15.9ms | ActiveRecord: 11.5ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:27:29 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  Rendered api/messages/index.json.jbuilder (7.4ms)
+Completed 200 OK in 31ms (Views: 24.3ms | ActiveRecord: 1.9ms)
+
+
+Started POST "/groups/17/messages" for ::1 at 2020-01-16 17:27:30 +0900
+Processing by MessagesController#create as JSON
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"GsDycVnkkwsfJI93GkDy5JUMMMBgUdhiFskknGs1HubhXyqdUxJVLClaVBZ1BE5qzB9oL8wFOGwjwQPQHDw/kA==", "message"=>{"content"=>"bbb"}, "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  [1m[35m (0.4ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (2.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 LIMIT 1[0m
+  [1m[35mSQL (7.4ms)[0m  [1m[32mINSERT INTO `messages` (`content`, `group_id`, `user_id`, `created_at`, `updated_at`) VALUES ('bbb', 17, 8, '2020-01-16 08:27:30', '2020-01-16 08:27:30')[0m
+  [1m[35m (3.9ms)[0m  [1m[35mCOMMIT[0m
+  Rendering messages/create.json.jbuilder
+  Rendered messages/create.json.jbuilder (0.8ms)
+Completed 200 OK in 52ms (Views: 22.5ms | ActiveRecord: 16.4ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:27:33 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (2.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (11.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (4.2ms)
+Completed 200 OK in 39ms (Views: 17.4ms | ActiveRecord: 15.2ms)
+
+
+Started GET "/groups/17/api/messages?id=55" for ::1 at 2020-01-16 17:27:33 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"55", "group_id"=>"17"}
+  [1m[36mUser Load (3.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 55)[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (3.3ms)
+Completed 200 OK in 24ms (Views: 14.8ms | ActiveRecord: 4.6ms)
+
+
+Started GET "/groups/17/api/messages?id=56" for ::1 at 2020-01-16 17:27:36 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"56", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 56)[0m
+  Rendered api/messages/index.json.jbuilder (1.8ms)
+Completed 200 OK in 24ms (Views: 14.4ms | ActiveRecord: 1.6ms)
+
+
+Started GET "/groups/17/api/messages?id=56" for ::1 at 2020-01-16 17:27:36 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"56", "group_id"=>"17"}
+  [1m[36mUser Load (10.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 56)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 38ms (Views: 16.8ms | ActiveRecord: 15.5ms)
+
+
+Started GET "/groups/17/api/messages?id=56" for ::1 at 2020-01-16 17:27:40 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"56", "group_id"=>"17"}
+  [1m[36mUser Load (7.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 56)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 26ms (Views: 13.9ms | ActiveRecord: 8.3ms)
+
+
+Started GET "/groups/17/api/messages?id=56" for ::1 at 2020-01-16 17:27:40 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"56", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 56)[0m
+  Rendered api/messages/index.json.jbuilder (2.7ms)
+Completed 200 OK in 27ms (Views: 20.2ms | ActiveRecord: 2.4ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 17:27:41 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (2.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (1.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (9.9ms)
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [9 times] (9.4ms)
+  Rendered messages/_main_chat.html.haml (19.6ms)
+  Rendered messages/index.html.haml within layouts/application (39.9ms)
+  Rendered layouts/_notifications.html.haml (2.9ms)
+Completed 200 OK in 92ms (Views: 77.7ms | ActiveRecord: 6.8ms)
+
+
+Started GET "/groups/17/api/messages?id=56" for ::1 at 2020-01-16 17:27:43 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"56", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 56)[0m
+  Rendered api/messages/index.json.jbuilder (2.9ms)
+Completed 200 OK in 28ms (Views: 21.5ms | ActiveRecord: 2.3ms)
+
+
+Started GET "/groups/17/api/messages?id=56" for ::1 at 2020-01-16 17:27:43 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"56", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 56)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 23ms (Views: 18.0ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/groups/17/api/messages?id=56" for ::1 at 2020-01-16 17:27:48 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"56", "group_id"=>"17"}
+  [1m[36mUser Load (2.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 56)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 20ms (Views: 10.8ms | ActiveRecord: 4.1ms)
+
+
+Started GET "/groups/17/api/messages?id=56" for ::1 at 2020-01-16 17:27:48 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"56", "group_id"=>"17"}
+  [1m[36mUser Load (3.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 56)[0m
+  Rendered api/messages/index.json.jbuilder (3.6ms)
+Completed 200 OK in 33ms (Views: 18.1ms | ActiveRecord: 8.1ms)
+
+
+Started GET "/groups/17/api/messages?id=56" for ::1 at 2020-01-16 17:27:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"56", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 56)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 23ms (Views: 15.2ms | ActiveRecord: 2.3ms)
+
+
+Started GET "/groups/17/api/messages?id=56" for ::1 at 2020-01-16 17:27:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"56", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 56)[0m
+  Rendered api/messages/index.json.jbuilder (2.4ms)
+Completed 200 OK in 25ms (Views: 16.6ms | ActiveRecord: 2.8ms)
+
+
+Started POST "/groups/17/messages" for ::1 at 2020-01-16 17:27:50 +0900
+Processing by MessagesController#create as JSON
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"5PFWZVOqxAHJObe/zPgi01rQ1aSPtIHngOd6W66WGZcfbo6JWVwCJv9HbN6jvJ5dA8ONSyPgYem1710X2Z844Q==", "message"=>{"content"=>"sss"}, "group_id"=>"17"}
+  [1m[36mUser Load (15.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (5.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  [1m[35m (0.2ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 LIMIT 1[0m
+  [1m[35mSQL (0.2ms)[0m  [1m[32mINSERT INTO `messages` (`content`, `group_id`, `user_id`, `created_at`, `updated_at`) VALUES ('sss', 17, 8, '2020-01-16 08:27:50', '2020-01-16 08:27:50')[0m
+  [1m[35m (0.6ms)[0m  [1m[35mCOMMIT[0m
+  Rendering messages/create.json.jbuilder
+  Rendered messages/create.json.jbuilder (0.6ms)
+Completed 200 OK in 46ms (Views: 13.3ms | ActiveRecord: 22.2ms)
+
+
+Started GET "/groups/17/api/messages?id=57" for ::1 at 2020-01-16 17:27:55 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"57", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 57)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 22ms (Views: 14.2ms | ActiveRecord: 3.3ms)
+
+
+Started GET "/groups/17/api/messages?id=57" for ::1 at 2020-01-16 17:27:55 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"57", "group_id"=>"17"}
+  [1m[36mUser Load (10.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (6.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 57)[0m
+  Rendered api/messages/index.json.jbuilder (2.1ms)
+Completed 200 OK in 36ms (Views: 12.9ms | ActiveRecord: 18.1ms)
+
+
+Started GET "/groups/17/api/messages?id=56" for ::1 at 2020-01-16 17:27:57 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"56", "group_id"=>"17"}
+  [1m[36mUser Load (2.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 56)[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (3.6ms)
+Completed 200 OK in 53ms (Views: 41.3ms | ActiveRecord: 3.7ms)
+
+
+Started GET "/groups/17/api/messages?id=56" for ::1 at 2020-01-16 17:27:57 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"56", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 56)[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (2.7ms)
+Completed 200 OK in 57ms (Views: 21.4ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=57" for ::1 at 2020-01-16 17:28:02 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"57", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 57)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 22ms (Views: 15.7ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=57" for ::1 at 2020-01-16 17:28:02 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"57", "group_id"=>"17"}
+  [1m[36mUser Load (1.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 57)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 28ms (Views: 20.7ms | ActiveRecord: 2.3ms)
+
+
+Started GET "/groups/17/api/messages?id=57" for ::1 at 2020-01-16 17:28:04 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"57", "group_id"=>"17"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 57)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 24ms (Views: 18.7ms | ActiveRecord: 1.6ms)
+
+
+Started GET "/groups/17/api/messages?id=57" for ::1 at 2020-01-16 17:28:04 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"57", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 57)[0m
+  Rendered api/messages/index.json.jbuilder (3.2ms)
+Completed 200 OK in 24ms (Views: 17.5ms | ActiveRecord: 1.3ms)
+
+
+Started POST "/groups/17/messages" for ::1 at 2020-01-16 17:28:06 +0900
+Processing by MessagesController#create as JSON
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"5PFWZVOqxAHJObe/zPgi01rQ1aSPtIHngOd6W66WGZcfbo6JWVwCJv9HbN6jvJ5dA8ONSyPgYem1710X2Z844Q==", "message"=>{"content"=>"ssss"}, "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (6.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  [1m[35m (1.0ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 LIMIT 1[0m
+  [1m[35mSQL (0.3ms)[0m  [1m[32mINSERT INTO `messages` (`content`, `group_id`, `user_id`, `created_at`, `updated_at`) VALUES ('ssss', 17, 8, '2020-01-16 08:28:06', '2020-01-16 08:28:06')[0m
+  [1m[35m (1.7ms)[0m  [1m[35mCOMMIT[0m
+  Rendering messages/create.json.jbuilder
+  Rendered messages/create.json.jbuilder (1.6ms)
+Completed 200 OK in 38ms (Views: 15.2ms | ActiveRecord: 11.0ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (6.5ms)
+Completed 200 OK in 32ms (Views: 22.1ms | ActiveRecord: 5.1ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (2.4ms)
+Completed 200 OK in 23ms (Views: 16.8ms | ActiveRecord: 2.4ms)
+
+
+Started GET "/groups/17/api/messages?id=57" for ::1 at 2020-01-16 17:28:11 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"57", "group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 57)[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (3.6ms)
+Completed 200 OK in 26ms (Views: 17.0ms | ActiveRecord: 4.0ms)
+
+
+Started GET "/groups/17/api/messages?id=57" for ::1 at 2020-01-16 17:28:11 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"57", "group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (9.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 57)[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (12.4ms)
+Completed 200 OK in 50ms (Views: 29.0ms | ActiveRecord: 11.7ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:17 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (7.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (7.8ms)
+Completed 200 OK in 33ms (Views: 18.2ms | ActiveRecord: 7.8ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:17 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (6.1ms)
+Completed 200 OK in 28ms (Views: 18.4ms | ActiveRecord: 5.9ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:18 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (6.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (41.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (43.9ms)
+Completed 200 OK in 87ms (Views: 25.3ms | ActiveRecord: 47.6ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:18 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (16.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 41ms (Views: 18.9ms | ActiveRecord: 17.9ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:24 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (5.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (36.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (2.6ms)
+Completed 200 OK in 86ms (Views: 37.3ms | ActiveRecord: 43.0ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:24 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (5.6ms)
+Completed 200 OK in 71ms (Views: 51.5ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:25 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (2.7ms)
+Completed 200 OK in 25ms (Views: 18.1ms | ActiveRecord: 1.6ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:25 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (3.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (13.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (16.4ms)
+Completed 200 OK in 41ms (Views: 19.3ms | ActiveRecord: 17.2ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:31 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (4.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (17.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (21.9ms)
+Completed 200 OK in 55ms (Views: 23.5ms | ActiveRecord: 23.3ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:31 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (7.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 27ms (Views: 13.3ms | ActiveRecord: 9.5ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:33 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (1.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (16.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (18.2ms)
+Completed 200 OK in 52ms (Views: 22.2ms | ActiveRecord: 22.2ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:33 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (6.9ms)
+Completed 200 OK in 44ms (Views: 26.7ms | ActiveRecord: 11.7ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:37 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (3.4ms)
+Completed 200 OK in 23ms (Views: 14.9ms | ActiveRecord: 3.6ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:37 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 31ms (Views: 15.5ms | ActiveRecord: 9.0ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:39 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (7.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (12.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (14.1ms)
+Completed 200 OK in 45ms (Views: 18.9ms | ActiveRecord: 21.4ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:39 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (21.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (41.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (43.6ms)
+Completed 200 OK in 89ms (Views: 21.2ms | ActiveRecord: 62.9ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:45 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (11.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (8.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (9.9ms)
+Completed 200 OK in 47ms (Views: 15.1ms | ActiveRecord: 21.9ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:45 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (12.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (13.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (18.3ms)
+Completed 200 OK in 74ms (Views: 32.8ms | ActiveRecord: 33.2ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:47 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (7.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (10.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (12.9ms)
+Completed 200 OK in 46ms (Views: 22.7ms | ActiveRecord: 18.1ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:47 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (1.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (12.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (14.4ms)
+Completed 200 OK in 37ms (Views: 18.1ms | ActiveRecord: 14.4ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:52 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (18.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (9.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (11.3ms)
+Completed 200 OK in 64ms (Views: 22.0ms | ActiveRecord: 30.2ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:52 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (8.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (10.1ms)
+Completed 200 OK in 38ms (Views: 23.6ms | ActiveRecord: 10.0ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:53 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (13.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (24.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (4.0ms)
+Completed 200 OK in 89ms (Views: 38.6ms | ActiveRecord: 39.1ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:53 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (8.8ms)
+Completed 200 OK in 53ms (Views: 32.4ms | ActiveRecord: 4.8ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:59 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (1.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (8.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (2.7ms)
+Completed 200 OK in 36ms (Views: 18.1ms | ActiveRecord: 10.9ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:28:59 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (7.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (8.6ms)
+Completed 200 OK in 36ms (Views: 19.6ms | ActiveRecord: 7.7ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:01 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (27.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (30.3ms)
+Completed 200 OK in 55ms (Views: 20.9ms | ActiveRecord: 29.4ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:01 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (15.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (14.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (37.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (41.5ms)
+Completed 200 OK in 118ms (Views: 40.7ms | ActiveRecord: 67.5ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:05 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (22.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (90.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (91.6ms)
+Completed 200 OK in 159ms (Views: 28.9ms | ActiveRecord: 117.4ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:06 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (5.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (116.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (118.1ms)
+Completed 200 OK in 165ms (Views: 36.0ms | ActiveRecord: 122.2ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:07 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (8.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (8.0ms)
+Completed 200 OK in 32ms (Views: 11.1ms | ActiveRecord: 15.9ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:07 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (3.3ms)
+Completed 200 OK in 35ms (Views: 28.3ms | ActiveRecord: 1.7ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:13 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (7.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (10.0ms)
+Completed 200 OK in 48ms (Views: 29.4ms | ActiveRecord: 13.1ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:13 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (20.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (27.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (6.9ms)
+Completed 200 OK in 81ms (Views: 20.6ms | ActiveRecord: 53.3ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:15 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 31ms (Views: 20.4ms | ActiveRecord: 0.9ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:15 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (2.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (7.8ms)
+Completed 200 OK in 33ms (Views: 13.9ms | ActiveRecord: 9.1ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:20 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (9.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (10.8ms)
+Completed 200 OK in 36ms (Views: 21.3ms | ActiveRecord: 10.3ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:20 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (12.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (8.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (13.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (16.8ms)
+Completed 200 OK in 62ms (Views: 23.3ms | ActiveRecord: 34.2ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:21 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (27.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (29.2ms)
+Completed 200 OK in 55ms (Views: 21.3ms | ActiveRecord: 28.2ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:21 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (7.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (8.4ms)
+Completed 200 OK in 33ms (Views: 20.8ms | ActiveRecord: 7.9ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:27 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (9.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (3.3ms)
+Completed 200 OK in 39ms (Views: 21.7ms | ActiveRecord: 11.5ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:27 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (2.9ms)
+Completed 200 OK in 30ms (Views: 22.7ms | ActiveRecord: 2.3ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:29 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (10.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (5.5ms)
+Completed 200 OK in 43ms (Views: 18.7ms | ActiveRecord: 15.8ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:29 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (4.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (6.6ms)
+Completed 200 OK in 43ms (Views: 25.3ms | ActiveRecord: 13.3ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:33 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (33.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (9.3ms)
+Completed 200 OK in 101ms (Views: 60.1ms | ActiveRecord: 33.6ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:33 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (23.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (8.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (13.3ms)
+Completed 200 OK in 71ms (Views: 19.3ms | ActiveRecord: 32.3ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:35 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (2.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (14.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (15.9ms)
+Completed 200 OK in 38ms (Views: 14.9ms | ActiveRecord: 17.3ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:35 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (16.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 40ms (Views: 15.4ms | ActiveRecord: 18.3ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:41 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (4.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (48.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (51.2ms)
+Completed 200 OK in 84ms (Views: 22.2ms | ActiveRecord: 56.1ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:41 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (15.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (35.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (38.2ms)
+Completed 200 OK in 85ms (Views: 24.0ms | ActiveRecord: 51.8ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:43 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (10.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (12.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (14.6ms)
+Completed 200 OK in 52ms (Views: 24.8ms | ActiveRecord: 22.9ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:43 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (5.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (9.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (10.3ms)
+Completed 200 OK in 45ms (Views: 23.4ms | ActiveRecord: 15.1ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:48 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (5.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (12.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (14.0ms)
+Completed 200 OK in 50ms (Views: 26.3ms | ActiveRecord: 18.7ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:48 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (1.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (2.1ms)
+Completed 200 OK in 34ms (Views: 16.9ms | ActiveRecord: 2.9ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:49 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (3.4ms)
+Completed 200 OK in 19ms (Views: 11.1ms | ActiveRecord: 2.8ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:49 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (12.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (3.3ms)
+Completed 200 OK in 39ms (Views: 18.5ms | ActiveRecord: 15.5ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:55 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (23.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (3.0ms)
+Completed 200 OK in 57ms (Views: 27.4ms | ActiveRecord: 23.8ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:55 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (19.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (26.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (5.5ms)
+Completed 200 OK in 96ms (Views: 42.8ms | ActiveRecord: 46.3ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:56 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (8.7ms)
+Completed 200 OK in 41ms (Views: 22.9ms | ActiveRecord: 9.2ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:29:56 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (5.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (28.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (30.5ms)
+Completed 200 OK in 61ms (Views: 21.2ms | ActiveRecord: 34.8ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:02 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (17.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (16.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (7.2ms)
+Completed 200 OK in 59ms (Views: 13.4ms | ActiveRecord: 39.7ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:02 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (2.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (13.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (21.9ms)
+Completed 200 OK in 57ms (Views: 31.4ms | ActiveRecord: 20.2ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:03 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 38ms (Views: 31.2ms | ActiveRecord: 1.9ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:03 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (21.5ms)
+Completed 200 OK in 147ms (Views: 132.6ms | ActiveRecord: 3.6ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (7.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (48.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (50.4ms)
+Completed 200 OK in 88ms (Views: 23.3ms | ActiveRecord: 57.4ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (4.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (29.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (30.4ms)
+Completed 200 OK in 61ms (Views: 18.0ms | ActiveRecord: 34.2ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:10 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (77.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (17.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (18.5ms)
+Completed 200 OK in 128ms (Views: 25.3ms | ActiveRecord: 95.7ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:10 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (1.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 27ms (Views: 16.9ms | ActiveRecord: 2.3ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 17:30:15 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (1.6ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (11.2ms)
+  [1m[36mUser Load (12.6ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (4.8ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [11 times] (10.3ms)
+  Rendered messages/_main_chat.html.haml (26.6ms)
+  Rendered messages/index.html.haml within layouts/application (61.8ms)
+  Rendered layouts/_notifications.html.haml (5.5ms)
+Completed 200 OK in 137ms (Views: 104.4ms | ActiveRecord: 20.9ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:15 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (2.1ms)
+Completed 200 OK in 26ms (Views: 16.3ms | ActiveRecord: 4.0ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:15 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (4.1ms)
+Completed 200 OK in 21ms (Views: 13.8ms | ActiveRecord: 3.9ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 17:30:16 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (4.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (11.3ms)
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (1.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [11 times] (6.5ms)
+  Rendered messages/_main_chat.html.haml (20.0ms)
+  Rendered messages/index.html.haml within layouts/application (41.3ms)
+  Rendered layouts/_notifications.html.haml (2.6ms)
+Completed 200 OK in 92ms (Views: 77.0ms | ActiveRecord: 9.3ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:22 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (3.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (7.4ms)
+Completed 200 OK in 41ms (Views: 25.7ms | ActiveRecord: 9.9ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:22 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (12.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (4.8ms)
+Completed 200 OK in 40ms (Views: 18.7ms | ActiveRecord: 16.3ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:23 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (5.4ms)
+Completed 200 OK in 33ms (Views: 24.1ms | ActiveRecord: 4.2ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:23 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (2.9ms)
+Completed 200 OK in 23ms (Views: 15.3ms | ActiveRecord: 2.9ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:29 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (19.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (17.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (19.4ms)
+Completed 200 OK in 70ms (Views: 21.4ms | ActiveRecord: 44.4ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:29 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (29.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (24.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (25.4ms)
+Completed 200 OK in 80ms (Views: 19.8ms | ActiveRecord: 55.3ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:30 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 31ms (Views: 19.7ms | ActiveRecord: 1.8ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:30 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (19.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (20.9ms)
+Completed 200 OK in 49ms (Views: 21.6ms | ActiveRecord: 20.3ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:36 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (1.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (1.8ms)
+Completed 200 OK in 32ms (Views: 23.9ms | ActiveRecord: 3.5ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:36 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (9.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (12.6ms)
+Completed 200 OK in 36ms (Views: 19.6ms | ActiveRecord: 10.9ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:37 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (5.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (2.2ms)
+Completed 200 OK in 29ms (Views: 14.6ms | ActiveRecord: 7.6ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:37 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (4.1ms)
+Completed 200 OK in 44ms (Views: 36.9ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:43 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 26ms (Views: 15.7ms | ActiveRecord: 2.2ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:43 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (8.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 25ms (Views: 11.0ms | ActiveRecord: 9.5ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:44 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 24ms (Views: 14.4ms | ActiveRecord: 2.6ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:44 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  Rendered api/messages/index.json.jbuilder (3.6ms)
+Completed 200 OK in 25ms (Views: 17.8ms | ActiveRecord: 2.2ms)
+
+
+Started POST "/groups/17/messages" for ::1 at 2020-01-16 17:30:45 +0900
+Processing by MessagesController#create as JSON
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"J9pkc1sOatLSJqA1WsBuwpRUAaZXrE4NdgyNqxA7f0DcRbyfUfis9eRYe1Q1hNJMzUdZSfv4rgNDBKrnZzJeNg==", "message"=>{"content"=>"aaaa"}, "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  [1m[35m (0.8ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 LIMIT 1[0m
+  [1m[35mSQL (0.3ms)[0m  [1m[32mINSERT INTO `messages` (`content`, `group_id`, `user_id`, `created_at`, `updated_at`) VALUES ('aaaa', 17, 8, '2020-01-16 08:30:45', '2020-01-16 08:30:45')[0m
+  [1m[35m (1.1ms)[0m  [1m[35mCOMMIT[0m
+  Rendering messages/create.json.jbuilder
+  Rendered messages/create.json.jbuilder (0.6ms)
+Completed 200 OK in 27ms (Views: 14.4ms | ActiveRecord: 3.9ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  [1m[36mUser Load (1.6ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (4.6ms)
+Completed 200 OK in 30ms (Views: 23.4ms | ActiveRecord: 2.5ms)
+
+
+Started GET "/groups/17/api/messages?id=58" for ::1 at 2020-01-16 17:30:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"58", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (17.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 58)[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (24.9ms)
+Completed 200 OK in 55ms (Views: 27.5ms | ActiveRecord: 18.5ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:30:51 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (3.7ms)
+Completed 200 OK in 29ms (Views: 23.6ms | ActiveRecord: 2.0ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:30:51 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (1.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 31ms (Views: 20.6ms | ActiveRecord: 2.0ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:30:57 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (3.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (2.9ms)
+Completed 200 OK in 30ms (Views: 15.6ms | ActiveRecord: 6.4ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:30:57 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (10.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 34ms (Views: 17.3ms | ActiveRecord: 12.1ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:30:58 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (2.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (18.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (2.1ms)
+Completed 200 OK in 48ms (Views: 17.8ms | ActiveRecord: 21.4ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:30:58 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (1.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (4.7ms)
+Completed 200 OK in 35ms (Views: 25.4ms | ActiveRecord: 4.3ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:04 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (2.6ms)
+Completed 200 OK in 22ms (Views: 15.0ms | ActiveRecord: 1.4ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:04 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (5.8ms)
+Completed 200 OK in 57ms (Views: 48.1ms | ActiveRecord: 3.5ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:05 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (2.1ms)
+Completed 200 OK in 21ms (Views: 15.5ms | ActiveRecord: 1.5ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:05 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (5.6ms)
+Completed 200 OK in 23ms (Views: 14.3ms | ActiveRecord: 5.2ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:11 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (2.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (6.6ms)
+Completed 200 OK in 29ms (Views: 15.4ms | ActiveRecord: 6.8ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:11 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (2.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (15.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (18.2ms)
+Completed 200 OK in 41ms (Views: 16.2ms | ActiveRecord: 19.2ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:12 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 22ms (Views: 12.3ms | ActiveRecord: 4.6ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:12 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (3.6ms)
+Completed 200 OK in 25ms (Views: 16.2ms | ActiveRecord: 1.9ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:18 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (2.2ms)
+Completed 200 OK in 22ms (Views: 16.0ms | ActiveRecord: 1.9ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:18 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (2.5ms)
+Completed 200 OK in 26ms (Views: 15.8ms | ActiveRecord: 4.6ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:19 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (6.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (5.4ms)
+Completed 200 OK in 29ms (Views: 13.0ms | ActiveRecord: 11.3ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:19 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (3.6ms)
+Completed 200 OK in 23ms (Views: 15.5ms | ActiveRecord: 3.4ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:25 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (56.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (5.9ms)
+Completed 200 OK in 87ms (Views: 21.2ms | ActiveRecord: 60.9ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:25 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (2.2ms)
+Completed 200 OK in 24ms (Views: 15.9ms | ActiveRecord: 2.0ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:26 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (13.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (3.2ms)
+Completed 200 OK in 45ms (Views: 22.0ms | ActiveRecord: 17.5ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:26 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (62.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (3.4ms)
+Completed 200 OK in 88ms (Views: 16.9ms | ActiveRecord: 65.5ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:33 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (7.0ms)
+Completed 200 OK in 39ms (Views: 29.6ms | ActiveRecord: 4.3ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:33 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (5.9ms)
+Completed 200 OK in 59ms (Views: 49.4ms | ActiveRecord: 5.0ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:34 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (6.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (5.8ms)
+Completed 200 OK in 33ms (Views: 16.2ms | ActiveRecord: 12.1ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:34 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (25.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (10.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (12.5ms)
+Completed 200 OK in 63ms (Views: 20.0ms | ActiveRecord: 36.1ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:39 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (22.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (24.2ms)
+Completed 200 OK in 44ms (Views: 16.6ms | ActiveRecord: 23.4ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:39 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (31.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (33.4ms)
+Completed 200 OK in 56ms (Views: 17.3ms | ActiveRecord: 32.4ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:41 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (37.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (38.0ms)
+Completed 200 OK in 70ms (Views: 18.6ms | ActiveRecord: 38.0ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:41 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (18.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (21.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (28.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (30.3ms)
+Completed 200 OK in 94ms (Views: 19.2ms | ActiveRecord: 69.3ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:47 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (3.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 47ms (Views: 38.9ms | ActiveRecord: 4.1ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:47 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (8.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (9.6ms)
+Completed 200 OK in 81ms (Views: 58.0ms | ActiveRecord: 11.5ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:47 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (2.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (11.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (2.1ms)
+Completed 200 OK in 67ms (Views: 34.5ms | ActiveRecord: 14.8ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:47 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (8.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (10.9ms)
+Completed 200 OK in 62ms (Views: 30.5ms | ActiveRecord: 9.5ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:53 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (19.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (6.5ms)
+Completed 200 OK in 48ms (Views: 12.2ms | ActiveRecord: 28.0ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:53 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (14.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (15.6ms)
+Completed 200 OK in 37ms (Views: 16.8ms | ActiveRecord: 15.3ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:55 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (5.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (8.7ms)
+Completed 200 OK in 34ms (Views: 19.1ms | ActiveRecord: 9.7ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:31:55 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (6.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (4.5ms)
+Completed 200 OK in 43ms (Views: 27.4ms | ActiveRecord: 10.4ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:01 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (1.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 35ms (Views: 23.5ms | ActiveRecord: 6.4ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:01 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (15.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (6.7ms)
+Completed 200 OK in 75ms (Views: 53.3ms | ActiveRecord: 17.2ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:02 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (19.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (30.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (34.3ms)
+Completed 200 OK in 78ms (Views: 20.8ms | ActiveRecord: 50.9ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:02 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (7.9ms)
+Completed 200 OK in 43ms (Views: 19.8ms | ActiveRecord: 8.8ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:07 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (27.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (34.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (35.2ms)
+Completed 200 OK in 91ms (Views: 18.6ms | ActiveRecord: 66.1ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:07 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (11.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (12.2ms)
+Completed 200 OK in 48ms (Views: 29.9ms | ActiveRecord: 12.7ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (65.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (319.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (321.0ms)
+Completed 200 OK in 431ms (Views: 34.3ms | ActiveRecord: 392.3ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (28.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (6.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (6.8ms)
+Completed 200 OK in 75ms (Views: 29.8ms | ActiveRecord: 38.1ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:15 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (101.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (5.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (22.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (23.9ms)
+Completed 200 OK in 164ms (Views: 24.2ms | ActiveRecord: 129.5ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:15 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (75.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (9.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (18.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (19.1ms)
+Completed 200 OK in 147ms (Views: 28.3ms | ActiveRecord: 102.9ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:16 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (1.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (40.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (27.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (34.1ms)
+Completed 200 OK in 123ms (Views: 33.8ms | ActiveRecord: 70.1ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:16 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (6.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (164.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (166.0ms)
+Completed 200 OK in 278ms (Views: 39.9ms | ActiveRecord: 171.1ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:21 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (6.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (22.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (23.7ms)
+Completed 200 OK in 54ms (Views: 18.2ms | ActiveRecord: 29.5ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:21 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (21.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (27.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (28.9ms)
+Completed 200 OK in 87ms (Views: 23.1ms | ActiveRecord: 55.3ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:23 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (24.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (10.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (9.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (10.3ms)
+Completed 200 OK in 73ms (Views: 19.0ms | ActiveRecord: 44.1ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:23 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (12.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (13.4ms)
+Completed 200 OK in 42ms (Views: 23.8ms | ActiveRecord: 14.0ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:29 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (7.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (20.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (1.8ms)
+Completed 200 OK in 55ms (Views: 20.5ms | ActiveRecord: 28.8ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:29 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (8.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (18.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (4.2ms)
+Completed 200 OK in 68ms (Views: 21.8ms | ActiveRecord: 28.6ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:30 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (9.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (7.1ms)
+Completed 200 OK in 39ms (Views: 15.8ms | ActiveRecord: 16.4ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:30 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (40.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (24.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (27.3ms)
+Completed 200 OK in 97ms (Views: 26.4ms | ActiveRecord: 65.4ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:35 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (2.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 32ms (Views: 16.1ms | ActiveRecord: 9.5ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:35 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (2.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (17.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (18.7ms)
+Completed 200 OK in 44ms (Views: 17.4ms | ActiveRecord: 20.7ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:37 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (5.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (12.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (13.4ms)
+Completed 200 OK in 46ms (Views: 23.3ms | ActiveRecord: 17.4ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:37 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (9.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (9.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (15.1ms)
+Completed 200 OK in 51ms (Views: 27.4ms | ActiveRecord: 18.8ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:43 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (12.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (32.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (34.1ms)
+Completed 200 OK in 77ms (Views: 22.4ms | ActiveRecord: 45.7ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:43 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (67.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (69.0ms)
+Completed 200 OK in 93ms (Views: 19.5ms | ActiveRecord: 68.9ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:44 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (12.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (14.0ms)
+Completed 200 OK in 38ms (Views: 20.9ms | ActiveRecord: 12.6ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:44 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (6.2ms)
+Completed 200 OK in 40ms (Views: 18.0ms | ActiveRecord: 6.2ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (28.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (29.4ms)
+Completed 200 OK in 55ms (Views: 15.9ms | ActiveRecord: 30.7ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (15.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (49.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (3.6ms)
+Completed 200 OK in 108ms (Views: 29.7ms | ActiveRecord: 65.9ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (3.4ms)
+Completed 200 OK in 55ms (Views: 49.1ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (9.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (12.9ms)
+Completed 200 OK in 38ms (Views: 24.7ms | ActiveRecord: 9.5ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:56 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (9.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (2.5ms)
+Completed 200 OK in 41ms (Views: 23.4ms | ActiveRecord: 11.1ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:56 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (5.0ms)
+Completed 200 OK in 38ms (Views: 25.1ms | ActiveRecord: 5.5ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:57 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (11.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (13.3ms)
+Completed 200 OK in 40ms (Views: 17.9ms | ActiveRecord: 12.4ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:32:57 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (2.1ms)
+Completed 200 OK in 20ms (Views: 14.4ms | ActiveRecord: 1.5ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 17:32:57 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (5.4ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (1.2ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (16.0ms)
+  [1m[36mUser Load (1.6ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [12 times] (9.9ms)
+  Rendered messages/_main_chat.html.haml (19.0ms)
+  Rendered messages/index.html.haml within layouts/application (47.5ms)
+  Rendered layouts/_notifications.html.haml (2.5ms)
+Completed 200 OK in 181ms (Views: 161.7ms | ActiveRecord: 11.6ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 17:33:00 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (9.0ms)
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [12 times] (8.2ms)
+  Rendered messages/_main_chat.html.haml (17.1ms)
+  Rendered messages/index.html.haml within layouts/application (35.2ms)
+  Rendered layouts/_notifications.html.haml (2.9ms)
+Completed 200 OK in 83ms (Views: 72.8ms | ActiveRecord: 2.3ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 17:33:00 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (2.5ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (15.0ms)
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (2.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [12 times] (4.3ms)
+  Rendered messages/_main_chat.html.haml (14.7ms)
+  Rendered messages/index.html.haml within layouts/application (38.6ms)
+  Rendered layouts/_notifications.html.haml (1.9ms)
+Completed 200 OK in 96ms (Views: 83.8ms | ActiveRecord: 7.1ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:33:05 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (3.5ms)
+Completed 200 OK in 23ms (Views: 15.1ms | ActiveRecord: 2.2ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:33:08 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (7.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (20.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  Rendered api/messages/index.json.jbuilder (2.4ms)
+Completed 200 OK in 62ms (Views: 27.4ms | ActiveRecord: 29.6ms)
+
+
+Started POST "/groups/17/messages" for ::1 at 2020-01-16 17:33:11 +0900
+Processing by MessagesController#create as JSON
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"ydsGr+NsifAVFbqfqdaUWidAbs0smBzICbs5yuQeU5oyRN5D6ZpP1yNrYf7GkijUflM2IoDM/MY8sx6Gkxdy7A==", "message"=>{"content"=>"type"}, "group_id"=>"17"}
+  [1m[36mUser Load (13.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  [1m[35m (1.7ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (2.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 LIMIT 1[0m
+  [1m[35mSQL (2.3ms)[0m  [1m[32mINSERT INTO `messages` (`content`, `group_id`, `user_id`, `created_at`, `updated_at`) VALUES ('type', 17, 8, '2020-01-16 08:33:11', '2020-01-16 08:33:11')[0m
+  [1m[35m (2.1ms)[0m  [1m[35mCOMMIT[0m
+  Rendering messages/create.json.jbuilder
+  Rendered messages/create.json.jbuilder (0.5ms)
+Completed 200 OK in 45ms (Views: 13.1ms | ActiveRecord: 22.3ms)
+
+
+Started GET "/groups/17/api/messages?id=60" for ::1 at 2020-01-16 17:33:12 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"60", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 60)[0m
+  Rendered api/messages/index.json.jbuilder (2.9ms)
+Completed 200 OK in 28ms (Views: 22.0ms | ActiveRecord: 2.5ms)
+
+
+Started GET "/groups/17/api/messages?id=59" for ::1 at 2020-01-16 17:33:15 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"59", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 59)[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (4.5ms)
+Completed 200 OK in 27ms (Views: 19.6ms | ActiveRecord: 1.6ms)
+
+
+Started GET "/groups/17/api/messages?id=60" for ::1 at 2020-01-16 17:33:19 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"60", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 60)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 17ms (Views: 11.8ms | ActiveRecord: 1.3ms)
+
+
+Started GET "/groups/17/api/messages?id=60" for ::1 at 2020-01-16 17:33:22 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"60", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 60)[0m
+  Rendered api/messages/index.json.jbuilder (2.7ms)
+Completed 200 OK in 24ms (Views: 16.9ms | ActiveRecord: 1.9ms)
+
+
+Started GET "/groups/17/api/messages?id=60" for ::1 at 2020-01-16 17:33:26 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"60", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 60)[0m
+  Rendered api/messages/index.json.jbuilder (7.5ms)
+Completed 200 OK in 28ms (Views: 18.4ms | ActiveRecord: 5.7ms)
+
+
+Started POST "/groups/17/messages" for ::1 at 2020-01-16 17:33:28 +0900
+Processing by MessagesController#create as JSON
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"s91885dSpZJ26Qvv96O5JGhgxlaFd6rK5kSgNp0UI1FIQqQfnaRjtUCX0I6Y5wWqMXOeuSkjSsTTTId66h0CJw==", "message"=>{"content"=>"どうかな"}, "group_id"=>"17"}
+  [1m[36mUser Load (2.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  [1m[35m (2.8ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 LIMIT 1[0m
+  [1m[35mSQL (0.5ms)[0m  [1m[32mINSERT INTO `messages` (`content`, `group_id`, `user_id`, `created_at`, `updated_at`) VALUES ('どうかな', 17, 8, '2020-01-16 08:33:28', '2020-01-16 08:33:28')[0m
+  [1m[35m (1.0ms)[0m  [1m[35mCOMMIT[0m
+  Rendering messages/create.json.jbuilder
+  Rendered messages/create.json.jbuilder (0.6ms)
+Completed 200 OK in 27ms (Views: 11.2ms | ActiveRecord: 7.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:33:29 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.2ms)
+Completed 200 OK in 27ms (Views: 19.3ms | ActiveRecord: 1.6ms)
+
+
+Started GET "/groups/17/api/messages?id=60" for ::1 at 2020-01-16 17:33:33 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"60", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (10.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (8.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 60)[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (11.5ms)
+Completed 200 OK in 57ms (Views: 29.4ms | ActiveRecord: 20.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:33:36 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.9ms)
+Completed 200 OK in 20ms (Views: 12.8ms | ActiveRecord: 2.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:33:40 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (12.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (13.7ms)
+Completed 200 OK in 53ms (Views: 21.1ms | ActiveRecord: 21.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:33:43 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (3.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (14.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (15.5ms)
+Completed 200 OK in 48ms (Views: 24.1ms | ActiveRecord: 18.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:33:48 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.6ms)
+Completed 200 OK in 40ms (Views: 28.0ms | ActiveRecord: 5.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:33:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (28.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (29.9ms)
+Completed 200 OK in 50ms (Views: 16.1ms | ActiveRecord: 29.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:33:54 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (37.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (10.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (35.9ms)
+Completed 200 OK in 109ms (Views: 51.7ms | ActiveRecord: 48.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:33:57 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (10.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (15.1ms)
+Completed 200 OK in 48ms (Views: 22.4ms | ActiveRecord: 15.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:34:01 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (11.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 38ms (Views: 19.4ms | ActiveRecord: 13.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:34:04 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (43.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (45.1ms)
+Completed 200 OK in 82ms (Views: 29.8ms | ActiveRecord: 45.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:34:08 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (9.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.1ms)
+Completed 200 OK in 37ms (Views: 17.6ms | ActiveRecord: 12.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:34:12 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (21.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (10.5ms)
+Completed 200 OK in 56ms (Views: 21.4ms | ActiveRecord: 30.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:34:16 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (4.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (22.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (20.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (21.1ms)
+Completed 200 OK in 71ms (Views: 16.0ms | ActiveRecord: 47.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:34:18 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (9.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (8.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (9.9ms)
+Completed 200 OK in 49ms (Views: 21.1ms | ActiveRecord: 18.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:34:22 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (4.1ms)
+Completed 200 OK in 38ms (Views: 26.9ms | ActiveRecord: 5.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:34:25 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (21.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (4.3ms)
+Completed 200 OK in 50ms (Views: 19.1ms | ActiveRecord: 24.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:34:29 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 31ms (Views: 20.9ms | ActiveRecord: 3.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:34:32 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (12.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 36ms (Views: 16.6ms | ActiveRecord: 12.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:34:36 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 28ms (Views: 20.6ms | ActiveRecord: 1.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:34:39 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (5.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 39ms (Views: 16.7ms | ActiveRecord: 6.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:34:43 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (5.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.9ms)
+Completed 200 OK in 35ms (Views: 21.4ms | ActiveRecord: 6.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:34:46 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (10.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 32ms (Views: 13.3ms | ActiveRecord: 13.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:34:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.1ms)
+Completed 200 OK in 30ms (Views: 20.1ms | ActiveRecord: 4.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:34:53 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.0ms)
+Completed 200 OK in 29ms (Views: 20.0ms | ActiveRecord: 2.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:34:57 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 29ms (Views: 22.6ms | ActiveRecord: 1.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:35:00 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (6.8ms)
+Completed 200 OK in 41ms (Views: 28.0ms | ActiveRecord: 8.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:35:04 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (11.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (13.1ms)
+Completed 200 OK in 41ms (Views: 21.7ms | ActiveRecord: 12.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:35:07 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (4.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (7.9ms)
+Completed 200 OK in 38ms (Views: 27.3ms | ActiveRecord: 6.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:35:11 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 24ms (Views: 18.5ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:35:14 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 23ms (Views: 15.4ms | ActiveRecord: 2.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:35:18 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (25.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 43ms (Views: 11.5ms | ActiveRecord: 26.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:35:21 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (8.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.2ms)
+Completed 200 OK in 32ms (Views: 15.9ms | ActiveRecord: 10.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:35:25 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.1ms)
+Completed 200 OK in 18ms (Views: 13.3ms | ActiveRecord: 1.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:35:28 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.2ms)
+Completed 200 OK in 24ms (Views: 15.9ms | ActiveRecord: 2.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:35:32 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 27ms (Views: 14.9ms | ActiveRecord: 5.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:35:35 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (9.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (10.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (12.0ms)
+Completed 200 OK in 47ms (Views: 19.6ms | ActiveRecord: 21.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:35:39 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (18.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (53.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (55.2ms)
+Completed 200 OK in 103ms (Views: 22.5ms | ActiveRecord: 74.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:35:43 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (24.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 69ms (Views: 37.1ms | ActiveRecord: 26.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:35:47 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (18.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (14.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (16.0ms)
+Completed 200 OK in 58ms (Views: 16.9ms | ActiveRecord: 34.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:35:49 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (12.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (14.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (13.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (14.7ms)
+Completed 200 OK in 69ms (Views: 22.1ms | ActiveRecord: 40.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:35:53 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (5.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (93.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (95.2ms)
+Completed 200 OK in 134ms (Views: 28.3ms | ActiveRecord: 100.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:35:56 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (43.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (15.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (17.3ms)
+Completed 200 OK in 82ms (Views: 15.7ms | ActiveRecord: 59.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:36:00 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (19.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (15.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (16.9ms)
+Completed 200 OK in 56ms (Views: 17.3ms | ActiveRecord: 34.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:36:04 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (5.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (8.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (7.7ms)
+Completed 200 OK in 45ms (Views: 19.1ms | ActiveRecord: 20.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:36:07 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (36.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (16.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (19.7ms)
+Completed 200 OK in 84ms (Views: 21.8ms | ActiveRecord: 56.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:36:10 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.3ms)
+Completed 200 OK in 40ms (Views: 34.1ms | ActiveRecord: 2.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:36:14 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (6.5ms)
+Completed 200 OK in 35ms (Views: 24.7ms | ActiveRecord: 6.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:36:18 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (13.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (15.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (17.4ms)
+Completed 200 OK in 54ms (Views: 17.9ms | ActiveRecord: 30.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:36:22 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (12.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (6.8ms)
+Completed 200 OK in 52ms (Views: 27.6ms | ActiveRecord: 18.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:36:24 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (6.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (20.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (22.5ms)
+Completed 200 OK in 61ms (Views: 26.3ms | ActiveRecord: 29.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:36:28 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (5.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (13.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (4.0ms)
+Completed 200 OK in 52ms (Views: 27.2ms | ActiveRecord: 19.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:36:31 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (34.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (28.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (41.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (46.3ms)
+Completed 200 OK in 129ms (Views: 19.0ms | ActiveRecord: 104.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:36:36 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (11.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (18.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (24.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (25.8ms)
+Completed 200 OK in 84ms (Views: 22.6ms | ActiveRecord: 54.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:36:39 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (6.9ms)
+Completed 200 OK in 37ms (Views: 23.8ms | ActiveRecord: 8.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:36:42 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (10.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (12.4ms)
+Completed 200 OK in 34ms (Views: 18.7ms | ActiveRecord: 10.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:36:45 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (5.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (30.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (14.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (15.3ms)
+Completed 200 OK in 83ms (Views: 28.7ms | ActiveRecord: 49.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:36:49 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (18.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (6.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.3ms)
+Completed 200 OK in 52ms (Views: 15.5ms | ActiveRecord: 27.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:36:53 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (10.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (11.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (13.9ms)
+Completed 200 OK in 57ms (Views: 27.0ms | ActiveRecord: 21.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:36:56 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (8.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (7.4ms)
+Completed 200 OK in 41ms (Views: 22.2ms | ActiveRecord: 13.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:36:59 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (26.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (28.3ms)
+Completed 200 OK in 53ms (Views: 19.6ms | ActiveRecord: 28.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:37:03 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.3ms)
+Completed 200 OK in 24ms (Views: 16.8ms | ActiveRecord: 2.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:37:06 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (9.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (30.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (32.2ms)
+Completed 200 OK in 69ms (Views: 21.7ms | ActiveRecord: 41.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:37:10 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (4.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.3ms)
+Completed 200 OK in 29ms (Views: 16.3ms | ActiveRecord: 8.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:37:13 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (12.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (34.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (25.3ms)
+Completed 200 OK in 139ms (Views: 81.3ms | ActiveRecord: 48.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:37:17 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (8.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (13.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (18.4ms)
+Completed 200 OK in 62ms (Views: 26.8ms | ActiveRecord: 26.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:37:21 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.5ms)
+Completed 200 OK in 37ms (Views: 23.5ms | ActiveRecord: 8.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:37:24 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (50.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (51.7ms)
+Completed 200 OK in 83ms (Views: 22.7ms | ActiveRecord: 55.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:37:27 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (6.8ms)
+Completed 200 OK in 32ms (Views: 21.6ms | ActiveRecord: 5.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:37:32 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (12.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.3ms)
+Completed 200 OK in 39ms (Views: 16.6ms | ActiveRecord: 14.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:37:34 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (36.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (33.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (35.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (39.6ms)
+Completed 200 OK in 143ms (Views: 25.0ms | ActiveRecord: 105.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:37:38 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (21.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (17.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (22.3ms)
+Completed 200 OK in 67ms (Views: 20.0ms | ActiveRecord: 39.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:37:41 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (9.4ms)
+Completed 200 OK in 42ms (Views: 28.2ms | ActiveRecord: 7.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:37:46 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (27.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (43.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (110.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (111.4ms)
+Completed 200 OK in 218ms (Views: 25.8ms | ActiveRecord: 180.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:37:49 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.8ms)
+Completed 200 OK in 36ms (Views: 28.0ms | ActiveRecord: 1.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:37:53 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (36.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (38.9ms)
+Completed 200 OK in 68ms (Views: 25.8ms | ActiveRecord: 37.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:37:56 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (3.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (12.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (14.5ms)
+Completed 200 OK in 69ms (Views: 33.9ms | ActiveRecord: 23.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:38:00 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.7ms)
+Completed 200 OK in 50ms (Views: 43.3ms | ActiveRecord: 1.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:38:02 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (12.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (14.2ms)
+Completed 200 OK in 43ms (Views: 23.5ms | ActiveRecord: 14.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:38:06 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (89.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (9.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (10.4ms)
+Completed 200 OK in 127ms (Views: 21.5ms | ActiveRecord: 99.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:38:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (9.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (25.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (27.7ms)
+Completed 200 OK in 64ms (Views: 18.5ms | ActiveRecord: 34.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:38:13 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (8.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (10.4ms)
+Completed 200 OK in 50ms (Views: 28.1ms | ActiveRecord: 13.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:38:16 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 62ms (Views: 53.7ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:38:20 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (15.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (4.9ms)
+Completed 200 OK in 41ms (Views: 16.6ms | ActiveRecord: 17.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:38:23 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (4.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (20.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (22.1ms)
+Completed 200 OK in 62ms (Views: 20.2ms | ActiveRecord: 32.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:38:28 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (8.1ms)
+Completed 200 OK in 35ms (Views: 23.2ms | ActiveRecord: 7.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:38:30 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (10.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (9.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (64.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (76.9ms)
+Completed 200 OK in 145ms (Views: 51.7ms | ActiveRecord: 84.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:38:34 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (18.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (19.4ms)
+Completed 200 OK in 39ms (Views: 14.8ms | ActiveRecord: 19.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:38:37 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (16.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (17.6ms)
+Completed 200 OK in 42ms (Views: 16.9ms | ActiveRecord: 19.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:38:42 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (36.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (27.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (19.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (20.7ms)
+Completed 200 OK in 105ms (Views: 16.3ms | ActiveRecord: 83.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:38:44 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (15.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 38ms (Views: 16.1ms | ActiveRecord: 15.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:38:48 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (56.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (65.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (68.0ms)
+Completed 200 OK in 156ms (Views: 24.0ms | ActiveRecord: 124.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:38:51 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (6.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (63.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (64.9ms)
+Completed 200 OK in 95ms (Views: 13.8ms | ActiveRecord: 70.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:38:56 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 26ms (Views: 17.4ms | ActiveRecord: 2.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:38:58 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.0ms)
+Completed 200 OK in 34ms (Views: 24.8ms | ActiveRecord: 3.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:39:03 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.2ms)
+Completed 200 OK in 25ms (Views: 17.7ms | ActiveRecord: 1.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:39:06 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (24.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (25.4ms)
+Completed 200 OK in 50ms (Views: 19.9ms | ActiveRecord: 24.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:39:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (25.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (4.3ms)
+Completed 200 OK in 60ms (Views: 25.2ms | ActiveRecord: 28.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:39:12 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (6.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (4.7ms)
+Completed 200 OK in 30ms (Views: 14.7ms | ActiveRecord: 9.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:39:16 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (5.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.3ms)
+Completed 200 OK in 34ms (Views: 17.3ms | ActiveRecord: 8.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:39:19 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (3.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 26ms (Views: 17.0ms | ActiveRecord: 4.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:39:24 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (17.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (25.7ms)
+Completed 200 OK in 51ms (Views: 22.5ms | ActiveRecord: 23.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:39:26 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (24.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (26.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (19.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (21.3ms)
+Completed 200 OK in 110ms (Views: 31.8ms | ActiveRecord: 71.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:39:30 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (12.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (6.0ms)
+Completed 200 OK in 40ms (Views: 19.4ms | ActiveRecord: 16.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:39:34 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (16.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (26.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (27.2ms)
+Completed 200 OK in 65ms (Views: 14.8ms | ActiveRecord: 44.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:39:38 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (10.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.8ms)
+Completed 200 OK in 41ms (Views: 22.9ms | ActiveRecord: 13.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:39:41 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (10.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.0ms)
+Completed 200 OK in 40ms (Views: 17.1ms | ActiveRecord: 14.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:39:44 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (13.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (16.0ms)
+Completed 200 OK in 44ms (Views: 23.6ms | ActiveRecord: 14.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:39:47 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (10.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.4ms)
+Completed 200 OK in 38ms (Views: 22.4ms | ActiveRecord: 11.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:39:51 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (18.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (19.8ms)
+Completed 200 OK in 47ms (Views: 16.5ms | ActiveRecord: 21.2ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 17:39:51 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (2.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (1.9ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (13.1ms)
+  [1m[36mUser Load (2.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [14 times] (13.5ms)
+  Rendered messages/_main_chat.html.haml (23.9ms)
+  Rendered messages/index.html.haml within layouts/application (51.8ms)
+  Rendered layouts/_notifications.html.haml (6.4ms)
+Completed 200 OK in 3100ms (Views: 3081.5ms | ActiveRecord: 11.3ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 17:40:00 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (1.6ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (5.7ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (16.0ms)
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (1.8ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [14 times] (7.7ms)
+  Rendered messages/_main_chat.html.haml (20.4ms)
+  Rendered messages/index.html.haml within layouts/application (49.2ms)
+  Rendered layouts/_notifications.html.haml (1.9ms)
+Completed 200 OK in 104ms (Views: 85.3ms | ActiveRecord: 11.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:40:08 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 26ms (Views: 18.2ms | ActiveRecord: 1.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:40:15 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (5.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 28ms (Views: 13.4ms | ActiveRecord: 6.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:40:22 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 20ms (Views: 14.6ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:40:29 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.9ms)
+Completed 200 OK in 22ms (Views: 15.6ms | ActiveRecord: 2.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:40:36 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 21ms (Views: 13.8ms | ActiveRecord: 1.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:40:43 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.0ms)
+Completed 200 OK in 26ms (Views: 17.3ms | ActiveRecord: 3.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:40:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (18.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 36ms (Views: 11.5ms | ActiveRecord: 19.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:40:57 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (17.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (19.9ms)
+Completed 200 OK in 39ms (Views: 16.2ms | ActiveRecord: 18.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:41:04 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 18ms (Views: 13.4ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:41:11 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (9.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (11.4ms)
+Completed 200 OK in 35ms (Views: 19.2ms | ActiveRecord: 11.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:41:18 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.3ms)
+Completed 200 OK in 29ms (Views: 19.1ms | ActiveRecord: 4.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:41:25 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (14.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.6ms)
+Completed 200 OK in 44ms (Views: 22.1ms | ActiveRecord: 16.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:41:32 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.4ms)
+Completed 200 OK in 23ms (Views: 14.2ms | ActiveRecord: 4.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:41:39 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.4ms)
+Completed 200 OK in 19ms (Views: 11.2ms | ActiveRecord: 4.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:41:46 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 32ms (Views: 25.3ms | ActiveRecord: 1.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:41:53 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 32ms (Views: 21.0ms | ActiveRecord: 2.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:42:00 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (19.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (20.5ms)
+Completed 200 OK in 54ms (Views: 22.2ms | ActiveRecord: 27.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:42:07 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.2ms)
+Completed 200 OK in 32ms (Views: 26.4ms | ActiveRecord: 1.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:42:14 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (10.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.4ms)
+Completed 200 OK in 50ms (Views: 26.3ms | ActiveRecord: 14.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:42:21 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 27ms (Views: 19.7ms | ActiveRecord: 1.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:42:28 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 27ms (Views: 16.8ms | ActiveRecord: 2.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:42:35 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.8ms)
+Completed 200 OK in 26ms (Views: 21.6ms | ActiveRecord: 1.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:42:42 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.2ms)
+Completed 200 OK in 23ms (Views: 16.0ms | ActiveRecord: 2.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:42:49 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.3ms)
+Completed 200 OK in 28ms (Views: 16.3ms | ActiveRecord: 5.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:42:56 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 28ms (Views: 17.9ms | ActiveRecord: 3.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:43:03 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 27ms (Views: 17.4ms | ActiveRecord: 2.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:43:10 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.3ms)
+Completed 200 OK in 20ms (Views: 13.4ms | ActiveRecord: 1.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:43:17 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (3.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 49ms (Views: 36.1ms | ActiveRecord: 6.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:43:24 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (17.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (19.7ms)
+Completed 200 OK in 44ms (Views: 21.9ms | ActiveRecord: 18.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:43:32 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (25.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (32.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 90ms (Views: 14.6ms | ActiveRecord: 58.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:43:38 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (29.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (32.0ms)
+Completed 200 OK in 57ms (Views: 21.2ms | ActiveRecord: 30.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:43:46 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (11.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (4.5ms)
+Completed 200 OK in 46ms (Views: 27.4ms | ActiveRecord: 13.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:43:52 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (35.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (5.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (9.0ms)
+Completed 200 OK in 112ms (Views: 64.7ms | ActiveRecord: 41.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:44:00 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (20.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (21.8ms)
+Completed 200 OK in 45ms (Views: 20.2ms | ActiveRecord: 21.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:44:06 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (16.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (18.2ms)
+Completed 200 OK in 41ms (Views: 19.3ms | ActiveRecord: 17.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:44:14 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (11.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (12.8ms)
+Completed 200 OK in 37ms (Views: 13.1ms | ActiveRecord: 17.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:44:20 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (8.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (10.7ms)
+Completed 200 OK in 49ms (Views: 28.7ms | ActiveRecord: 11.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:44:28 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (6.6ms)
+Completed 200 OK in 37ms (Views: 26.0ms | ActiveRecord: 5.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:44:34 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (15.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (20.2ms)
+Completed 200 OK in 45ms (Views: 21.1ms | ActiveRecord: 17.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:44:42 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (13.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (14.3ms)
+Completed 200 OK in 38ms (Views: 18.4ms | ActiveRecord: 13.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:44:49 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (6.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (13.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (15.1ms)
+Completed 200 OK in 45ms (Views: 19.5ms | ActiveRecord: 20.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:44:55 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (15.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (16.0ms)
+Completed 200 OK in 38ms (Views: 16.5ms | ActiveRecord: 16.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:45:03 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (15.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 36ms (Views: 13.8ms | ActiveRecord: 17.3ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 17:45:07 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (6.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (1.5ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (19.5ms)
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (5.5ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [14 times] (10.0ms)
+  Rendered messages/_main_chat.html.haml (93.9ms)
+  Rendered messages/index.html.haml within layouts/application (134.9ms)
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:45:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (100.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (55.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.9ms)
+Completed 200 OK in 184ms (Views: 16.0ms | ActiveRecord: 161.2ms)
+
+
+  Rendered layouts/_notifications.html.haml (3.1ms)
+Completed 200 OK in 3022ms (Views: 2998.8ms | ActiveRecord: 16.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:45:17 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.6ms)
+Completed 200 OK in 33ms (Views: 21.9ms | ActiveRecord: 5.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:45:18 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.9ms)
+Completed 200 OK in 29ms (Views: 16.3ms | ActiveRecord: 5.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:45:23 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (20.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (18.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 66ms (Views: 16.6ms | ActiveRecord: 38.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:45:25 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (5.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (20.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.4ms)
+Completed 200 OK in 49ms (Views: 16.7ms | ActiveRecord: 27.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:45:30 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.8ms)
+Completed 200 OK in 24ms (Views: 17.7ms | ActiveRecord: 1.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:45:32 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (15.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (17.4ms)
+Completed 200 OK in 41ms (Views: 16.3ms | ActiveRecord: 18.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:45:37 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (16.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.4ms)
+Completed 200 OK in 67ms (Views: 43.7ms | ActiveRecord: 18.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:45:39 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (49.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (50.7ms)
+Completed 200 OK in 79ms (Views: 21.2ms | ActiveRecord: 52.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:45:44 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (19.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (20.8ms)
+Completed 200 OK in 55ms (Views: 19.3ms | ActiveRecord: 29.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:45:46 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.2ms)
+Completed 200 OK in 22ms (Views: 14.7ms | ActiveRecord: 2.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:45:51 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (6.2ms)
+Completed 200 OK in 31ms (Views: 20.1ms | ActiveRecord: 6.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:45:53 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (11.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (12.4ms)
+Completed 200 OK in 30ms (Views: 13.1ms | ActiveRecord: 12.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:45:59 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (23.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.3ms)
+Completed 200 OK in 63ms (Views: 33.4ms | ActiveRecord: 25.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:46:01 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (6.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.8ms)
+Completed 200 OK in 42ms (Views: 21.0ms | ActiveRecord: 7.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:46:05 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (3.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (141.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (143.8ms)
+Completed 200 OK in 179ms (Views: 27.7ms | ActiveRecord: 145.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:46:08 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.0ms)
+Completed 200 OK in 33ms (Views: 25.5ms | ActiveRecord: 2.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:46:12 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (17.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (14.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (7.8ms)
+Completed 200 OK in 77ms (Views: 31.1ms | ActiveRecord: 35.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:46:15 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 46ms (Views: 40.9ms | ActiveRecord: 0.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:46:19 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (7.6ms)
+Completed 200 OK in 32ms (Views: 22.4ms | ActiveRecord: 5.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:46:22 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (35.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.8ms)
+Completed 200 OK in 144ms (Views: 94.5ms | ActiveRecord: 40.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:46:26 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (12.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (14.1ms)
+Completed 200 OK in 39ms (Views: 20.6ms | ActiveRecord: 13.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:46:28 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (8.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 36ms (Views: 21.9ms | ActiveRecord: 8.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:46:33 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (22.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (23.8ms)
+Completed 200 OK in 50ms (Views: 19.0ms | ActiveRecord: 23.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:46:36 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (24.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (24.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (26.0ms)
+Completed 200 OK in 74ms (Views: 18.0ms | ActiveRecord: 50.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:46:40 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (12.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (14.3ms)
+Completed 200 OK in 36ms (Views: 16.9ms | ActiveRecord: 14.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:46:42 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 23ms (Views: 17.0ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:46:48 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (17.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (19.9ms)
+Completed 200 OK in 49ms (Views: 21.5ms | ActiveRecord: 20.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:46:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (43.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (45.6ms)
+Completed 200 OK in 77ms (Views: 20.4ms | ActiveRecord: 45.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:46:54 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (109.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (14.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (9.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (11.0ms)
+Completed 200 OK in 157ms (Views: 19.6ms | ActiveRecord: 132.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:46:56 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (8.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (10.2ms)
+Completed 200 OK in 37ms (Views: 18.8ms | ActiveRecord: 13.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:47:02 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (4.1ms)
+Completed 200 OK in 31ms (Views: 25.5ms | ActiveRecord: 1.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:47:04 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (16.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (15.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 59ms (Views: 17.4ms | ActiveRecord: 31.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:47:08 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (359.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (330.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 710ms (Views: 14.9ms | ActiveRecord: 689.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:47:10 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (15.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (37.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.5ms)
+Completed 200 OK in 85ms (Views: 23.0ms | ActiveRecord: 56.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:47:16 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (5.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (10.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (11.6ms)
+Completed 200 OK in 44ms (Views: 18.7ms | ActiveRecord: 16.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:47:18 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.1ms)
+Completed 200 OK in 89ms (Views: 75.8ms | ActiveRecord: 7.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:47:22 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (30.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (15.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (6.5ms)
+Completed 200 OK in 96ms (Views: 35.7ms | ActiveRecord: 50.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:47:24 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (3.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (46.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (47.5ms)
+Completed 200 OK in 79ms (Views: 23.6ms | ActiveRecord: 49.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:47:30 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (7.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (51.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (54.7ms)
+Completed 200 OK in 84ms (Views: 18.8ms | ActiveRecord: 59.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:47:31 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.6ms)
+Completed 200 OK in 20ms (Views: 14.0ms | ActiveRecord: 2.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:47:37 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (14.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (13.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (15.9ms)
+Completed 200 OK in 68ms (Views: 31.2ms | ActiveRecord: 30.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:47:39 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (62.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (18.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (20.8ms)
+Completed 200 OK in 110ms (Views: 20.3ms | ActiveRecord: 83.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:47:44 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (6.5ms)
+Completed 200 OK in 34ms (Views: 17.9ms | ActiveRecord: 10.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:47:45 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (11.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (6.2ms)
+Completed 200 OK in 40ms (Views: 17.1ms | ActiveRecord: 16.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:47:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (22.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (50.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (7.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (8.1ms)
+Completed 200 OK in 105ms (Views: 17.4ms | ActiveRecord: 80.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:47:52 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (37.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (7.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (8.9ms)
+Completed 200 OK in 81ms (Views: 27.2ms | ActiveRecord: 46.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:47:58 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 18ms (Views: 12.4ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:48:00 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (4.9ms)
+Completed 200 OK in 41ms (Views: 29.9ms | ActiveRecord: 3.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:48:04 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (21.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (17.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (19.1ms)
+Completed 200 OK in 59ms (Views: 12.9ms | ActiveRecord: 40.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:48:06 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (16.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 42ms (Views: 12.9ms | ActiveRecord: 17.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:48:12 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (13.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (10.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (11.7ms)
+Completed 200 OK in 46ms (Views: 17.4ms | ActiveRecord: 23.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:48:13 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (3.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.2ms)
+Completed 200 OK in 35ms (Views: 21.8ms | ActiveRecord: 7.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:48:18 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.7ms)
+Completed 200 OK in 24ms (Views: 14.7ms | ActiveRecord: 4.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:48:20 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (5.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 27ms (Views: 15.4ms | ActiveRecord: 5.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:48:26 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (4.4ms)
+Completed 200 OK in 36ms (Views: 24.8ms | ActiveRecord: 5.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:48:27 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.7ms)
+Completed 200 OK in 26ms (Views: 19.6ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:48:32 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.0ms)
+Completed 200 OK in 21ms (Views: 13.7ms | ActiveRecord: 1.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:48:34 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 31ms (Views: 21.0ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:48:40 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 26ms (Views: 18.3ms | ActiveRecord: 1.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:48:41 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.1ms)
+Completed 200 OK in 22ms (Views: 13.3ms | ActiveRecord: 3.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:48:46 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 57ms (Views: 50.6ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:48:48 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.5ms)
+Completed 200 OK in 23ms (Views: 13.8ms | ActiveRecord: 2.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:48:54 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 25ms (Views: 16.0ms | ActiveRecord: 3.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:48:55 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (4.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.6ms)
+Completed 200 OK in 25ms (Views: 14.0ms | ActiveRecord: 5.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:49:00 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (4.2ms)
+Completed 200 OK in 32ms (Views: 24.7ms | ActiveRecord: 1.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:49:02 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 48ms (Views: 39.9ms | ActiveRecord: 3.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:49:08 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (8.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (12.7ms)
+Completed 200 OK in 43ms (Views: 25.2ms | ActiveRecord: 10.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:49:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.4ms)
+Completed 200 OK in 33ms (Views: 23.8ms | ActiveRecord: 4.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:49:15 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.3ms)
+Completed 200 OK in 24ms (Views: 15.0ms | ActiveRecord: 4.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:49:16 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.9ms)
+Completed 200 OK in 23ms (Views: 15.3ms | ActiveRecord: 3.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:49:22 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (4.2ms)
+Completed 200 OK in 23ms (Views: 14.1ms | ActiveRecord: 3.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:49:23 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.2ms)
+Completed 200 OK in 26ms (Views: 18.3ms | ActiveRecord: 2.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:49:28 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.3ms)
+Completed 200 OK in 30ms (Views: 19.9ms | ActiveRecord: 4.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:49:30 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.5ms)
+Completed 200 OK in 21ms (Views: 14.5ms | ActiveRecord: 1.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:49:35 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (10.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.8ms)
+Completed 200 OK in 34ms (Views: 17.1ms | ActiveRecord: 11.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:49:37 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.6ms)
+Completed 200 OK in 25ms (Views: 16.9ms | ActiveRecord: 2.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:49:42 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.2ms)
+Completed 200 OK in 34ms (Views: 26.7ms | ActiveRecord: 2.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:49:44 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 29ms (Views: 17.9ms | ActiveRecord: 1.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:49:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (11.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (13.7ms)
+Completed 200 OK in 33ms (Views: 15.9ms | ActiveRecord: 12.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:49:51 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 24ms (Views: 17.1ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:49:56 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (14.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (13.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (17.3ms)
+Completed 200 OK in 54ms (Views: 15.7ms | ActiveRecord: 29.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:49:59 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.2ms)
+Completed 200 OK in 24ms (Views: 15.9ms | ActiveRecord: 3.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:50:03 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (8.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (7.2ms)
+Completed 200 OK in 43ms (Views: 21.3ms | ActiveRecord: 13.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:50:05 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.6ms)
+Completed 200 OK in 33ms (Views: 28.2ms | ActiveRecord: 1.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:50:10 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.4ms)
+Completed 200 OK in 34ms (Views: 20.7ms | ActiveRecord: 8.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:50:13 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (10.5ms)
+Completed 200 OK in 38ms (Views: 23.5ms | ActiveRecord: 5.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:50:18 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.6ms)
+Completed 200 OK in 39ms (Views: 29.3ms | ActiveRecord: 4.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:50:19 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 23ms (Views: 16.8ms | ActiveRecord: 1.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:50:25 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (8.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.7ms)
+Completed 200 OK in 37ms (Views: 19.4ms | ActiveRecord: 9.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:50:27 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (17.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (4.4ms)
+Completed 200 OK in 41ms (Views: 15.1ms | ActiveRecord: 20.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:50:31 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (3.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 65ms (Views: 52.6ms | ActiveRecord: 7.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:50:34 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (5.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.0ms)
+Completed 200 OK in 29ms (Views: 16.3ms | ActiveRecord: 7.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:50:38 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (8.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (24.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (26.6ms)
+Completed 200 OK in 62ms (Views: 20.0ms | ActiveRecord: 34.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:50:40 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.8ms)
+Completed 200 OK in 34ms (Views: 17.4ms | ActiveRecord: 4.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:50:46 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (6.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (32.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (34.8ms)
+Completed 200 OK in 73ms (Views: 23.1ms | ActiveRecord: 42.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:50:48 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (4.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (25.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (27.6ms)
+Completed 200 OK in 58ms (Views: 18.1ms | ActiveRecord: 31.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:50:52 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (14.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.6ms)
+Completed 200 OK in 41ms (Views: 13.5ms | ActiveRecord: 19.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:50:54 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (9.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (10.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (11.6ms)
+Completed 200 OK in 44ms (Views: 15.9ms | ActiveRecord: 23.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:50:59 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.5ms)
+Completed 200 OK in 57ms (Views: 47.5ms | ActiveRecord: 4.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:51:01 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (7.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (8.7ms)
+Completed 200 OK in 41ms (Views: 27.4ms | ActiveRecord: 9.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:51:06 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (14.1ms)
+Completed 200 OK in 45ms (Views: 37.9ms | ActiveRecord: 1.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:51:08 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.1ms)
+Completed 200 OK in 35ms (Views: 19.5ms | ActiveRecord: 8.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:51:14 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (37.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (7.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (12.4ms)
+Completed 200 OK in 73ms (Views: 22.6ms | ActiveRecord: 45.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:51:16 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (33.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (36.8ms)
+Completed 200 OK in 66ms (Views: 27.4ms | ActiveRecord: 34.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:51:20 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (4.9ms)
+Completed 200 OK in 34ms (Views: 24.3ms | ActiveRecord: 4.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:51:22 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (7.2ms)
+Completed 200 OK in 37ms (Views: 26.6ms | ActiveRecord: 5.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:51:27 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.8ms)
+Completed 200 OK in 28ms (Views: 14.4ms | ActiveRecord: 8.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:51:30 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 26ms (Views: 20.1ms | ActiveRecord: 1.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:51:34 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (6.4ms)
+Completed 200 OK in 27ms (Views: 17.7ms | ActiveRecord: 4.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:51:36 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (9.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (11.0ms)
+Completed 200 OK in 33ms (Views: 19.2ms | ActiveRecord: 10.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:51:41 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (7.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.4ms)
+Completed 200 OK in 38ms (Views: 14.7ms | ActiveRecord: 14.2ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 17:51:41 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (9.8ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (26.7ms)
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [14 times] (12.8ms)
+  Rendered messages/_main_chat.html.haml (40.4ms)
+  Rendered messages/index.html.haml within layouts/application (81.1ms)
+  Rendered layouts/_notifications.html.haml (2.4ms)
+Completed 200 OK in 172ms (Views: 154.2ms | ActiveRecord: 12.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:51:43 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.9ms)
+Completed 200 OK in 39ms (Views: 30.0ms | ActiveRecord: 4.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:51:48 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 21ms (Views: 15.6ms | ActiveRecord: 1.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:51:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 18ms (Views: 11.8ms | ActiveRecord: 1.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:51:55 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (4.0ms)
+Completed 200 OK in 30ms (Views: 21.9ms | ActiveRecord: 3.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:51:58 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (7.9ms)
+Completed 200 OK in 30ms (Views: 17.6ms | ActiveRecord: 7.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:52:02 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 24ms (Views: 13.8ms | ActiveRecord: 4.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:52:04 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (54.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (7.1ms)
+Completed 200 OK in 82ms (Views: 17.7ms | ActiveRecord: 61.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:52:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (5.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 39ms (Views: 27.3ms | ActiveRecord: 6.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:52:12 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (31.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 57ms (Views: 17.9ms | ActiveRecord: 35.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:52:16 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (5.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 25ms (Views: 13.1ms | ActiveRecord: 6.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:52:18 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 24ms (Views: 19.1ms | ActiveRecord: 1.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:52:23 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.0ms)
+Completed 200 OK in 28ms (Views: 19.6ms | ActiveRecord: 5.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:52:25 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (4.2ms)
+Completed 200 OK in 28ms (Views: 19.8ms | ActiveRecord: 3.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:52:30 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (9.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (10.3ms)
+Completed 200 OK in 39ms (Views: 21.8ms | ActiveRecord: 11.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:52:33 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 25ms (Views: 12.5ms | ActiveRecord: 5.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:52:37 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (9.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.5ms)
+Completed 200 OK in 33ms (Views: 15.5ms | ActiveRecord: 12.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:52:39 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 27ms (Views: 20.9ms | ActiveRecord: 2.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:52:44 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (9.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (10.5ms)
+Completed 200 OK in 31ms (Views: 13.8ms | ActiveRecord: 11.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:52:47 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 33ms (Views: 13.3ms | ActiveRecord: 4.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:52:51 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 25ms (Views: 18.9ms | ActiveRecord: 1.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:52:53 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (4.2ms)
+Completed 200 OK in 33ms (Views: 18.0ms | ActiveRecord: 3.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:52:58 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 16ms (Views: 10.3ms | ActiveRecord: 1.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:53:01 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.9ms)
+Completed 200 OK in 24ms (Views: 16.6ms | ActiveRecord: 3.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:53:05 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.3ms)
+Completed 200 OK in 28ms (Views: 23.1ms | ActiveRecord: 1.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:53:08 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.1ms)
+Completed 200 OK in 29ms (Views: 19.3ms | ActiveRecord: 2.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:53:12 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (24.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (27.4ms)
+Completed 200 OK in 48ms (Views: 17.9ms | ActiveRecord: 26.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:53:15 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 29ms (Views: 20.4ms | ActiveRecord: 2.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:53:19 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.8ms)
+Completed 200 OK in 22ms (Views: 16.4ms | ActiveRecord: 1.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:53:22 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 25ms (Views: 18.7ms | ActiveRecord: 1.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:53:26 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (18.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (32.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (36.0ms)
+Completed 200 OK in 80ms (Views: 23.5ms | ActiveRecord: 51.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:53:29 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (4.3ms)
+Completed 200 OK in 20ms (Views: 12.8ms | ActiveRecord: 3.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:53:33 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (6.6ms)
+Completed 200 OK in 33ms (Views: 19.1ms | ActiveRecord: 9.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:53:36 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 24ms (Views: 12.6ms | ActiveRecord: 6.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:53:40 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.6ms)
+Completed 200 OK in 28ms (Views: 18.6ms | ActiveRecord: 4.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:53:42 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.7ms)
+Completed 200 OK in 27ms (Views: 18.3ms | ActiveRecord: 4.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:53:47 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.5ms)
+Completed 200 OK in 20ms (Views: 13.5ms | ActiveRecord: 1.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:53:49 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 26ms (Views: 18.5ms | ActiveRecord: 1.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:53:54 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (5.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 25ms (Views: 13.3ms | ActiveRecord: 6.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:53:56 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.8ms)
+Completed 200 OK in 22ms (Views: 11.9ms | ActiveRecord: 5.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:54:01 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 25ms (Views: 18.0ms | ActiveRecord: 3.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:54:04 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 25ms (Views: 14.5ms | ActiveRecord: 2.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:54:08 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (9.5ms)
+Completed 200 OK in 33ms (Views: 20.4ms | ActiveRecord: 8.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:54:10 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (20.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.9ms)
+Completed 200 OK in 45ms (Views: 16.1ms | ActiveRecord: 23.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:54:15 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (7.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (9.0ms)
+Completed 200 OK in 40ms (Views: 21.5ms | ActiveRecord: 11.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:54:18 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (18.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (21.8ms)
+Completed 200 OK in 70ms (Views: 47.0ms | ActiveRecord: 18.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:54:22 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 21ms (Views: 16.4ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:54:24 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (72.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (6.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 104ms (Views: 18.3ms | ActiveRecord: 79.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:54:29 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (4.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 30ms (Views: 20.5ms | ActiveRecord: 4.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:54:32 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.3ms)
+Completed 200 OK in 28ms (Views: 18.8ms | ActiveRecord: 4.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:54:36 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (6.8ms)
+Completed 200 OK in 33ms (Views: 23.9ms | ActiveRecord: 4.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:54:39 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.4ms)
+Completed 200 OK in 22ms (Views: 14.2ms | ActiveRecord: 1.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:54:43 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 37ms (Views: 27.2ms | ActiveRecord: 1.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:54:45 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (11.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.9ms)
+Completed 200 OK in 46ms (Views: 19.1ms | ActiveRecord: 13.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:54:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (3.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (8.1ms)
+Completed 200 OK in 33ms (Views: 12.4ms | ActiveRecord: 13.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:54:52 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.0ms)
+Completed 200 OK in 24ms (Views: 13.1ms | ActiveRecord: 1.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:54:57 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.8ms)
+Completed 200 OK in 21ms (Views: 13.1ms | ActiveRecord: 2.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:55:00 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (7.4ms)
+Completed 200 OK in 34ms (Views: 20.8ms | ActiveRecord: 7.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:55:04 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.2ms)
+Completed 200 OK in 25ms (Views: 18.4ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:55:06 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.3ms)
+Completed 200 OK in 26ms (Views: 20.2ms | ActiveRecord: 1.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:55:11 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (3.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 24ms (Views: 15.2ms | ActiveRecord: 4.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:55:14 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.0ms)
+Completed 200 OK in 23ms (Views: 15.5ms | ActiveRecord: 1.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:55:18 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.0ms)
+Completed 200 OK in 20ms (Views: 12.7ms | ActiveRecord: 2.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:55:21 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (6.1ms)
+Completed 200 OK in 25ms (Views: 16.3ms | ActiveRecord: 4.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:55:25 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.3ms)
+Completed 200 OK in 20ms (Views: 14.1ms | ActiveRecord: 2.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:55:28 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (5.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (7.3ms)
+Completed 200 OK in 36ms (Views: 20.5ms | ActiveRecord: 10.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:55:32 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (4.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 28ms (Views: 16.1ms | ActiveRecord: 5.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:55:35 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 23ms (Views: 15.2ms | ActiveRecord: 3.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:55:39 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (24.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (25.7ms)
+Completed 200 OK in 55ms (Views: 22.3ms | ActiveRecord: 25.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:55:41 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (15.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (16.2ms)
+Completed 200 OK in 39ms (Views: 17.7ms | ActiveRecord: 16.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:55:46 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (3.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.9ms)
+Completed 200 OK in 24ms (Views: 11.7ms | ActiveRecord: 8.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:55:48 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (10.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (13.2ms)
+Completed 200 OK in 32ms (Views: 13.5ms | ActiveRecord: 13.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:55:53 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.4ms)
+Completed 200 OK in 22ms (Views: 14.2ms | ActiveRecord: 2.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:55:56 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.5ms)
+Completed 200 OK in 23ms (Views: 18.4ms | ActiveRecord: 0.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:56:00 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (13.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.0ms)
+Completed 200 OK in 42ms (Views: 20.6ms | ActiveRecord: 14.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:56:02 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.5ms)
+Completed 200 OK in 21ms (Views: 14.7ms | ActiveRecord: 2.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:56:07 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.9ms)
+Completed 200 OK in 24ms (Views: 14.6ms | ActiveRecord: 4.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:56:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 25ms (Views: 19.7ms | ActiveRecord: 0.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:56:14 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (12.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.3ms)
+Completed 200 OK in 34ms (Views: 15.3ms | ActiveRecord: 12.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:56:16 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (56.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.4ms)
+Completed 200 OK in 81ms (Views: 13.1ms | ActiveRecord: 62.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:56:21 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (3.3ms)
+Completed 200 OK in 28ms (Views: 17.3ms | ActiveRecord: 5.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:56:23 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (43.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (46.7ms)
+Completed 200 OK in 66ms (Views: 16.6ms | ActiveRecord: 44.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:56:28 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (3.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (4.4ms)
+Completed 200 OK in 30ms (Views: 17.2ms | ActiveRecord: 7.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:56:30 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (21.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (9.9ms)
+Completed 200 OK in 54ms (Views: 18.4ms | ActiveRecord: 30.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:56:35 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (6.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.3ms)
+Completed 200 OK in 30ms (Views: 17.5ms | ActiveRecord: 8.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:56:38 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.8ms)
+Completed 200 OK in 26ms (Views: 18.5ms | ActiveRecord: 2.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:56:42 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.4ms)
+Completed 200 OK in 23ms (Views: 17.1ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:56:44 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.9ms)
+Completed 200 OK in 27ms (Views: 18.5ms | ActiveRecord: 4.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:56:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (16.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (19.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (20.7ms)
+Completed 200 OK in 60ms (Views: 18.7ms | ActiveRecord: 36.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:56:52 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (2.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.1ms)
+Completed 200 OK in 27ms (Views: 15.0ms | ActiveRecord: 3.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:56:57 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (66.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (118.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (8.0ms)
+Completed 200 OK in 214ms (Views: 14.6ms | ActiveRecord: 192.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:56:58 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (10.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (12.3ms)
+Completed 200 OK in 40ms (Views: 24.3ms | ActiveRecord: 11.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:57:04 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (39.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (9.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (10.6ms)
+Completed 200 OK in 73ms (Views: 18.0ms | ActiveRecord: 49.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:57:05 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (7.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.1ms)
+Completed 200 OK in 32ms (Views: 14.4ms | ActiveRecord: 11.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:57:11 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.7ms)
+Completed 200 OK in 32ms (Views: 23.1ms | ActiveRecord: 2.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:57:12 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 29ms (Views: 22.1ms | ActiveRecord: 1.8ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:57:18 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (27.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (11.0ms)
+Completed 200 OK in 65ms (Views: 25.6ms | ActiveRecord: 30.5ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:57:20 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (18.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 60ms (Views: 34.5ms | ActiveRecord: 20.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:57:25 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (12.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 35ms (Views: 18.0ms | ActiveRecord: 12.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:57:26 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (7.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (6.7ms)
+Completed 200 OK in 44ms (Views: 23.4ms | ActiveRecord: 13.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:57:32 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (7.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (5.2ms)
+Completed 200 OK in 38ms (Views: 17.1ms | ActiveRecord: 13.6ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:57:34 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (5.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (24.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (26.2ms)
+Completed 200 OK in 51ms (Views: 17.0ms | ActiveRecord: 30.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:57:39 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (24.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (26.6ms)
+Completed 200 OK in 64ms (Views: 30.4ms | ActiveRecord: 25.4ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:57:41 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (7.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (25.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (26.1ms)
+Completed 200 OK in 75ms (Views: 28.3ms | ActiveRecord: 39.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:57:46 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (9.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (14.6ms)
+Completed 200 OK in 55ms (Views: 28.5ms | ActiveRecord: 19.9ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:57:48 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (10.5ms)
+Completed 200 OK in 34ms (Views: 26.8ms | ActiveRecord: 2.7ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:57:53 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (14.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (8.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (10.2ms)
+Completed 200 OK in 56ms (Views: 21.5ms | ActiveRecord: 24.2ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:57:54 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (8.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (10.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (12.1ms)
+Completed 200 OK in 69ms (Views: 42.8ms | ActiveRecord: 19.3ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:58:00 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (7.1ms)
+Completed 200 OK in 25ms (Views: 16.6ms | ActiveRecord: 4.9ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 17:58:00 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (1.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (2.2ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (14.4ms)
+  [1m[36mUser Load (6.0ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (1.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [14 times] (8.9ms)
+  Rendered messages/_main_chat.html.haml (24.4ms)
+  Rendered messages/index.html.haml within layouts/application (57.0ms)
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:58:01 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (16.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (17.2ms)
+Completed 200 OK in 41ms (Views: 18.3ms | ActiveRecord: 17.7ms)
+
+
+  Rendered layouts/_notifications.html.haml (2.2ms)
+Completed 200 OK in 2577ms (Views: 2557.2ms | ActiveRecord: 14.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:58:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (2.8ms)
+Completed 200 OK in 28ms (Views: 23.8ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:58:10 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 17ms (Views: 11.7ms | ActiveRecord: 0.9ms)
+
+
+Started POST "/groups/17/messages" for ::1 at 2020-01-16 17:58:12 +0900
+Processing by MessagesController#create as JSON
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"vl+UzoMTwweAjRQAenZ+ZOBLZRwONKeLOKE0mpFbFP1FwEwiieUFILbzz2EVMsLquVg986JgR4UNqRPW5lI1iw==", "message"=>{"content"=>"again"}, "group_id"=>"17"}
+  [1m[36mUser Load (1.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  [1m[35m (1.6ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (25.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 LIMIT 1[0m
+  [1m[35mSQL (2.1ms)[0m  [1m[32mINSERT INTO `messages` (`content`, `group_id`, `user_id`, `created_at`, `updated_at`) VALUES ('again', 17, 8, '2020-01-16 08:58:12', '2020-01-16 08:58:12')[0m
+  [1m[35m (1.5ms)[0m  [1m[35mCOMMIT[0m
+  Rendering messages/create.json.jbuilder
+  Rendered messages/create.json.jbuilder (0.9ms)
+Completed 200 OK in 58ms (Views: 11.1ms | ActiveRecord: 32.1ms)
+
+
+Started GET "/groups/17/api/messages?id=61" for ::1 at 2020-01-16 17:58:15 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"61", "group_id"=>"17"}
+  [1m[36mUser Load (7.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 61)[0m
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (4.5ms)
+Completed 200 OK in 34ms (Views: 17.0ms | ActiveRecord: 10.7ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:58:17 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (1.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (8.4ms)
+Completed 200 OK in 32ms (Views: 18.9ms | ActiveRecord: 8.1ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:58:22 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (14.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (22.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (28.1ms)
+Completed 200 OK in 113ms (Views: 62.9ms | ActiveRecord: 39.5ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:58:25 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 24ms (Views: 18.8ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:58:29 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (14.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (2.5ms)
+Completed 200 OK in 37ms (Views: 14.2ms | ActiveRecord: 15.9ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:58:32 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 22ms (Views: 15.6ms | ActiveRecord: 1.4ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:58:36 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (2.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (2.7ms)
+Completed 200 OK in 30ms (Views: 17.2ms | ActiveRecord: 7.4ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:58:39 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (2.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 24ms (Views: 15.9ms | ActiveRecord: 3.6ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:58:44 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (7.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 32ms (Views: 13.1ms | ActiveRecord: 12.0ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:58:46 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (4.0ms)
+Completed 200 OK in 29ms (Views: 20.3ms | ActiveRecord: 4.3ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:58:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 15ms (Views: 9.5ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:58:53 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (2.7ms)
+Completed 200 OK in 19ms (Views: 11.2ms | ActiveRecord: 2.9ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:58:58 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 19ms (Views: 12.1ms | ActiveRecord: 2.2ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:59:00 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (4.1ms)
+Completed 200 OK in 26ms (Views: 18.8ms | ActiveRecord: 3.8ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:59:05 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 18ms (Views: 12.7ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:59:07 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 17ms (Views: 12.9ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:59:12 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (10.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (12.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (2.3ms)
+Completed 200 OK in 46ms (Views: 15.2ms | ActiveRecord: 24.0ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:59:14 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 19ms (Views: 13.1ms | ActiveRecord: 0.9ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:59:18 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 18ms (Views: 12.5ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:59:21 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 18ms (Views: 13.0ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:59:25 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 17ms (Views: 12.4ms | ActiveRecord: 0.9ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:59:28 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 18ms (Views: 13.6ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:59:32 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 17ms (Views: 11.5ms | ActiveRecord: 1.4ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:59:35 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 17ms (Views: 11.1ms | ActiveRecord: 1.3ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:59:39 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 15ms (Views: 10.9ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:59:42 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (13.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 33ms (Views: 12.5ms | ActiveRecord: 15.4ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:59:47 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 21ms (Views: 13.9ms | ActiveRecord: 2.5ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:59:49 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 18ms (Views: 13.0ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:59:53 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (6.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (4.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 30ms (Views: 13.7ms | ActiveRecord: 11.1ms)
+
+
+Started GET "/groups/17/api/messages?id=62" for ::1 at 2020-01-16 17:59:56 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"62", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 62)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 18ms (Views: 11.8ms | ActiveRecord: 1.7ms)
+
+

--- a/log/development.log
+++ b/log/development.log
@@ -7250,3 +7250,3968 @@ Processing by MessagesController#index as HTML
 Completed 200 OK in 65ms (Views: 58.4ms | ActiveRecord: 1.9ms)
 
 
+Started GET "/" for ::1 at 2020-01-16 00:39:39 +0900
+  [1m[36mActiveRecord::SchemaMigration Load (6.8ms)[0m  [1m[34mSELECT `schema_migrations`.* FROM `schema_migrations`[0m
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (6.4ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 4[0m
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (107.0ms)
+  Rendered groups/index.html.haml within layouts/application (118.8ms)
+  Rendered layouts/_notifications.html.haml (2.2ms)
+Completed 200 OK in 525ms (Views: 470.2ms | ActiveRecord: 31.7ms)
+
+
+Started GET "/groups/7/messages" for ::1 at 2020-01-16 00:39:47 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"7"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 7 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 4[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (9.1ms)
+  [1m[36mUser Load (2.5ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 7[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 4[0m
+  Rendered collection of messages/_message.html.haml [16 times] (8.5ms)
+  Rendered messages/_main_chat.html.haml (31.2ms)
+  Rendered messages/index.html.haml within layouts/application (55.2ms)
+  Rendered layouts/_notifications.html.haml (2.1ms)
+Completed 200 OK in 108ms (Views: 98.9ms | ActiveRecord: 4.0ms)
+
+
+Started GET "/groups/7/edit" for ::1 at 2020-01-16 00:39:58 +0900
+Processing by GroupsController#edit as HTML
+  Parameters: {"id"=>"7"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 7 LIMIT 1[0m
+  Rendering groups/edit.html.haml within layouts/application
+  Rendered groups/_form.html.haml (984.6ms)
+  Rendered groups/edit.html.haml within layouts/application (990.9ms)
+  Rendered layouts/_notifications.html.haml (1.8ms)
+Completed 200 OK in 1023ms (Views: 1018.6ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/users/4/edit" for ::1 at 2020-01-16 00:40:25 +0900
+Processing by UsersController#edit as HTML
+  Parameters: {"id"=>"4"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/edit.html.haml within layouts/application
+  Rendered users/edit.html.haml within layouts/application (8.4ms)
+  Rendered layouts/_notifications.html.haml (1.5ms)
+Completed 200 OK in 53ms (Views: 47.1ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 00:40:29 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (6.8ms)
+  Rendered groups/new.html.haml within layouts/application (10.0ms)
+  Rendered layouts/_notifications.html.haml (1.5ms)
+Completed 200 OK in 49ms (Views: 38.5ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/users?keyword=c" for ::1 at 2020-01-16 00:40:48 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"c"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%c%') AND (`users`.`id` != 4) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (1.2ms)
+Completed 200 OK in 17ms (Views: 12.2ms | ActiveRecord: 0.5ms)
+
+
+Started POST "/groups" for ::1 at 2020-01-16 00:40:56 +0900
+Processing by GroupsController#create as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"CRgUS9KM0QHzl6aITlLAwYLMDwCayfBUwZvB+C1P6ohW+qCNFdxSjzbHqjEx+U5mZO67boU2nXULx/YJlQ9Ylg==", "group"=>{"name"=>"chat0116", "user_ids"=>["1", "3"]}, "commit"=>"登録する"}
+  [1m[36mUser Load (3.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mUser Load (5.6ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` IN (1, 3)[0m
+  [1m[35m (10.4ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mGroup Exists (0.5ms)[0m  [1m[34mSELECT  1 AS one FROM `groups` WHERE `groups`.`name` = BINARY 'chat0116' LIMIT 1[0m
+  [1m[35mSQL (1.5ms)[0m  [1m[32mINSERT INTO `groups` (`name`, `created_at`, `updated_at`) VALUES ('chat0116', '2020-01-15 15:40:56', '2020-01-15 15:40:56')[0m
+  [1m[35mSQL (0.4ms)[0m  [1m[32mINSERT INTO `group_users` (`group_id`, `user_id`, `created_at`, `updated_at`) VALUES (10, 1, '2020-01-15 15:40:56', '2020-01-15 15:40:56')[0m
+  [1m[35mSQL (0.1ms)[0m  [1m[32mINSERT INTO `group_users` (`group_id`, `user_id`, `created_at`, `updated_at`) VALUES (10, 3, '2020-01-15 15:40:56', '2020-01-15 15:40:56')[0m
+  [1m[35m (30.5ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 68ms (ActiveRecord: 52.1ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 00:40:56 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 4[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (10.7ms)
+  Rendered groups/index.html.haml within layouts/application (17.5ms)
+  Rendered layouts/_notifications.html.haml (1.8ms)
+Completed 200 OK in 51ms (Views: 46.2ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 00:40:59 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 4[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (6.3ms)
+  Rendered groups/index.html.haml within layouts/application (10.6ms)
+  Rendered layouts/_notifications.html.haml (2.1ms)
+Completed 200 OK in 47ms (Views: 43.7ms | ActiveRecord: 0.9ms)
+
+
+Started GET "/groups/7/messages" for ::1 at 2020-01-16 00:41:05 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"7"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 7 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 4[0m
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (8.6ms)
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 7[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7[0m
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 4[0m
+  Rendered collection of messages/_message.html.haml [16 times] (6.0ms)
+  Rendered messages/_main_chat.html.haml (14.6ms)
+  Rendered messages/index.html.haml within layouts/application (33.7ms)
+  Rendered layouts/_notifications.html.haml (1.4ms)
+Completed 200 OK in 74ms (Views: 67.9ms | ActiveRecord: 3.1ms)
+
+
+Started GET "/groups/7/messages" for ::1 at 2020-01-16 00:41:13 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"7"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 7 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 4[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (7.2ms)
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 7[0m
+  [1m[36mMessage Load (0.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 4[0m
+  Rendered collection of messages/_message.html.haml [16 times] (4.8ms)
+  Rendered messages/_main_chat.html.haml (14.8ms)
+  Rendered messages/index.html.haml within layouts/application (32.2ms)
+  Rendered layouts/_notifications.html.haml (2.6ms)
+Completed 200 OK in 65ms (Views: 58.5ms | ActiveRecord: 3.1ms)
+
+
+Started GET "/groups/7/edit" for ::1 at 2020-01-16 00:41:25 +0900
+Processing by GroupsController#edit as HTML
+  Parameters: {"id"=>"7"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 7 LIMIT 1[0m
+  Rendering groups/edit.html.haml within layouts/application
+  Rendered groups/_form.html.haml (7.6ms)
+  Rendered groups/edit.html.haml within layouts/application (11.2ms)
+  Rendered layouts/_notifications.html.haml (1.9ms)
+Completed 200 OK in 44ms (Views: 39.2ms | ActiveRecord: 0.9ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 00:41:33 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (8.9ms)
+  Rendered groups/new.html.haml within layouts/application (12.4ms)
+  Rendered layouts/_notifications.html.haml (1.5ms)
+Completed 200 OK in 46ms (Views: 40.3ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/users?keyword=c" for ::1 at 2020-01-16 00:41:57 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"c"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%c%') AND (`users`.`id` != 4) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (1.2ms)
+Completed 200 OK in 15ms (Views: 10.6ms | ActiveRecord: 0.5ms)
+
+
+Started POST "/groups" for ::1 at 2020-01-16 00:42:06 +0900
+Processing by GroupsController#create as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"VneZ9hjnGXb8U/lOt0NSU0EaAfh55JDDMeutdHmYxGMJlS0w37ea+DkD9ffI6Nz0pzi1lmYb/eL7t5qFwdh2fQ==", "group"=>{"name"=>"chat01116", "user_ids"=>["3"]}, "commit"=>"登録する"}
+  [1m[36mUser Load (9.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 3[0m
+  [1m[35m (1.3ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mGroup Exists (0.5ms)[0m  [1m[34mSELECT  1 AS one FROM `groups` WHERE `groups`.`name` = BINARY 'chat01116' LIMIT 1[0m
+  [1m[35mSQL (0.2ms)[0m  [1m[32mINSERT INTO `groups` (`name`, `created_at`, `updated_at`) VALUES ('chat01116', '2020-01-15 15:42:06', '2020-01-15 15:42:06')[0m
+  [1m[35mSQL (0.2ms)[0m  [1m[32mINSERT INTO `group_users` (`group_id`, `user_id`, `created_at`, `updated_at`) VALUES (11, 3, '2020-01-15 15:42:06', '2020-01-15 15:42:06')[0m
+  [1m[35m (0.7ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 24ms (ActiveRecord: 12.4ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 00:42:06 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 4[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (7.7ms)
+  Rendered groups/index.html.haml within layouts/application (11.9ms)
+  Rendered layouts/_notifications.html.haml (2.4ms)
+Completed 200 OK in 58ms (Views: 53.1ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 00:42:09 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 4[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (5.9ms)
+  Rendered groups/index.html.haml within layouts/application (8.9ms)
+  Rendered layouts/_notifications.html.haml (1.7ms)
+Completed 200 OK in 46ms (Views: 41.6ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/users/4/edit" for ::1 at 2020-01-16 00:42:18 +0900
+Processing by UsersController#edit as HTML
+  Parameters: {"id"=>"4"}
+  [1m[36mUser Load (5.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/edit.html.haml within layouts/application
+  Rendered users/edit.html.haml within layouts/application (4.9ms)
+  Rendered layouts/_notifications.html.haml (2.4ms)
+Completed 200 OK in 48ms (Views: 39.0ms | ActiveRecord: 5.1ms)
+
+
+Started PATCH "/users/4" for ::1 at 2020-01-16 00:42:38 +0900
+Processing by UsersController#update as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"3X2YKsU8ZDW6/+KBiIZ+SD/1kQVmu03AyyUIFWPcDKWCnyzsAmznu3+v7jj3LfDv2dcla3lEIOEBeT/k25y+uw==", "user"=>{"name"=>"chat0116", "email"=>"chat0116@gmail.com"}, "commit"=>"Update", "id"=>"4"}
+  [1m[36mUser Load (10.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[35m (3.2ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists (1.1ms)[0m  [1m[34mSELECT  1 AS one FROM `users` WHERE `users`.`email` = BINARY 'chat0116@gmail.com' AND (`users`.`id` != 4) LIMIT 1[0m
+  [1m[35mSQL (1.4ms)[0m  [1m[33mUPDATE `users` SET `name` = 'chat0116', `email` = 'chat0116@gmail.com', `updated_at` = '2020-01-15 15:42:38' WHERE `users`.`id` = 4[0m
+  [1m[35m (1.1ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 25ms (ActiveRecord: 17.5ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 00:42:38 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 4[0m
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (10.3ms)
+  Rendered groups/index.html.haml within layouts/application (14.2ms)
+  Rendered layouts/_notifications.html.haml (1.4ms)
+Completed 200 OK in 54ms (Views: 48.5ms | ActiveRecord: 1.8ms)
+
+
+Started GET "/groups/7/messages" for ::1 at 2020-01-16 00:42:49 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"7"}
+  [1m[36mUser Load (15.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 7 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (4.1ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 4[0m
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (16.8ms)
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 7[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 4[0m
+  Rendered collection of messages/_message.html.haml [16 times] (6.9ms)
+  Rendered messages/_main_chat.html.haml (17.4ms)
+  Rendered messages/index.html.haml within layouts/application (42.6ms)
+  Rendered layouts/_notifications.html.haml (2.0ms)
+Completed 200 OK in 122ms (Views: 88.0ms | ActiveRecord: 28.7ms)
+
+
+Started GET "/groups/7/messages" for ::1 at 2020-01-16 00:42:58 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"7"}
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 7 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 4[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (13.3ms)
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 7[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7[0m
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 4[0m
+  Rendered collection of messages/_message.html.haml [16 times] (4.8ms)
+  Rendered messages/_main_chat.html.haml (13.6ms)
+  Rendered messages/index.html.haml within layouts/application (34.6ms)
+  Rendered layouts/_notifications.html.haml (1.6ms)
+Completed 200 OK in 68ms (Views: 59.5ms | ActiveRecord: 3.3ms)
+
+
+Started GET "/groups/7/messages" for ::1 at 2020-01-16 00:43:03 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"7"}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 7 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 4[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (6.3ms)
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 7[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 4[0m
+  Rendered collection of messages/_message.html.haml [16 times] (7.5ms)
+  Rendered messages/_main_chat.html.haml (13.7ms)
+  Rendered messages/index.html.haml within layouts/application (28.0ms)
+  Rendered layouts/_notifications.html.haml (2.0ms)
+Completed 200 OK in 69ms (Views: 58.8ms | ActiveRecord: 4.2ms)
+
+
+Started GET "/groups/7/edit" for ::1 at 2020-01-16 00:43:08 +0900
+Processing by GroupsController#edit as HTML
+  Parameters: {"id"=>"7"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 7 LIMIT 1[0m
+  Rendering groups/edit.html.haml within layouts/application
+  Rendered groups/_form.html.haml (7.5ms)
+  Rendered groups/edit.html.haml within layouts/application (11.4ms)
+  Rendered layouts/_notifications.html.haml (1.8ms)
+Completed 200 OK in 50ms (Views: 45.0ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/users?keyword=c" for ::1 at 2020-01-16 00:43:14 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"c"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%c%') AND (`users`.`id` != 4) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (2.4ms)
+Completed 200 OK in 16ms (Views: 11.8ms | ActiveRecord: 1.5ms)
+
+
+Started PATCH "/groups/7" for ::1 at 2020-01-16 00:43:19 +0900
+Processing by GroupsController#update as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"5Q2giLTapmwf1eLcutk1z2h+ATRSdKdxRsWORDeaa6C67xROc4ol4tqF7mXFcrtojly1Wk2LylCMmbm1j9rZvg==", "group"=>{"name"=>"chatgroup0110", "user_ids"=>["3"]}, "commit"=>"更新する", "id"=>"7"}
+  [1m[36mUser Load (4.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 7 LIMIT 1[0m
+  [1m[35m (0.2ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (4.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 3[0m
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 7[0m
+  [1m[35mSQL (0.2ms)[0m  [1m[31mDELETE FROM `group_users` WHERE `group_users`.`group_id` = 7 AND `group_users`.`user_id` IN (1, 4)[0m
+  [1m[35mSQL (0.2ms)[0m  [1m[32mINSERT INTO `group_users` (`group_id`, `user_id`, `created_at`, `updated_at`) VALUES (7, 3, '2020-01-15 15:43:19', '2020-01-15 15:43:19')[0m
+  [1m[36mGroup Exists (0.3ms)[0m  [1m[34mSELECT  1 AS one FROM `groups` WHERE `groups`.`name` = BINARY 'chatgroup0110' AND (`groups`.`id` != 7) LIMIT 1[0m
+  [1m[35m (0.4ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/groups/7/messages
+Completed 302 Found in 26ms (ActiveRecord: 14.3ms)
+
+
+Started GET "/groups/7/messages" for ::1 at 2020-01-16 00:43:19 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"7"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 7 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 4[0m
+  Rendered shared/_side_bar.html.haml (5.1ms)
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 7[0m
+  [1m[36mMessage Load (5.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 4[0m
+  Rendered collection of messages/_message.html.haml [16 times] (4.7ms)
+  Rendered messages/_main_chat.html.haml (21.0ms)
+  Rendered messages/index.html.haml within layouts/application (36.0ms)
+  Rendered layouts/_notifications.html.haml (2.1ms)
+Completed 200 OK in 78ms (Views: 66.4ms | ActiveRecord: 7.1ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 00:43:26 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (9.9ms)
+  Rendered groups/new.html.haml within layouts/application (13.9ms)
+  Rendered layouts/_notifications.html.haml (2.2ms)
+Completed 200 OK in 54ms (Views: 48.0ms | ActiveRecord: 0.4ms)
+
+
+Started GET "/users/4/edit" for ::1 at 2020-01-16 00:43:30 +0900
+Processing by UsersController#edit as HTML
+  Parameters: {"id"=>"4"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/edit.html.haml within layouts/application
+  Rendered users/edit.html.haml within layouts/application (4.9ms)
+  Rendered layouts/_notifications.html.haml (1.8ms)
+Completed 200 OK in 37ms (Views: 33.3ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/7/messages" for ::1 at 2020-01-16 00:43:34 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"7"}
+  [1m[36mUser Load (5.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 7 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 4[0m
+  Rendered shared/_side_bar.html.haml (18.3ms)
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 7[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 4[0m
+  Rendered collection of messages/_message.html.haml [16 times] (5.8ms)
+  Rendered messages/_main_chat.html.haml (14.1ms)
+  Rendered messages/index.html.haml within layouts/application (39.9ms)
+  Rendered layouts/_notifications.html.haml (1.5ms)
+Completed 200 OK in 96ms (Views: 80.1ms | ActiveRecord: 9.9ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 00:43:41 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (6.8ms)
+  Rendered groups/new.html.haml within layouts/application (10.0ms)
+  Rendered layouts/_notifications.html.haml (1.5ms)
+Completed 200 OK in 53ms (Views: 48.4ms | ActiveRecord: 0.3ms)
+
+
+Started GET "/users/4/edit" for ::1 at 2020-01-16 00:43:45 +0900
+Processing by UsersController#edit as HTML
+  Parameters: {"id"=>"4"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/edit.html.haml within layouts/application
+  Rendered users/edit.html.haml within layouts/application (5.1ms)
+  Rendered layouts/_notifications.html.haml (1.6ms)
+Completed 200 OK in 41ms (Views: 36.6ms | ActiveRecord: 0.4ms)
+
+
+Started PATCH "/users/4" for ::1 at 2020-01-16 00:43:49 +0900
+Processing by UsersController#update as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"77yVzF0jiFX5+FhP1Ux5GtH4mhKQ+QgUiHwkABQ1LLewXiEKmnML2zyoVPaq5/e9N9oufI8GZTVCIBPxrHWeqQ==", "user"=>{"name"=>"chat0116", "email"=>"chat0116@gmail.com"}, "commit"=>"Update", "id"=>"4"}
+  [1m[36mUser Load (8.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[35m (0.9ms)[0m  [1m[35mBEGIN[0m
+  [1m[35m (0.1ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 14ms (ActiveRecord: 9.2ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 00:43:49 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 4[0m
+  Rendered shared/_side_bar.html.haml (4.3ms)
+  Rendered groups/index.html.haml within layouts/application (7.6ms)
+  Rendered layouts/_notifications.html.haml (1.7ms)
+Completed 200 OK in 40ms (Views: 35.1ms | ActiveRecord: 0.6ms)
+
+
+Started DELETE "/users/sign_out" for ::1 at 2020-01-16 00:44:03 +0900
+Processing by Devise::SessionsController#destroy as HTML
+  Parameters: {"authenticity_token"=>"77yVzF0jiFX5+FhP1Ux5GtH4mhKQ+QgUiHwkABQ1LLewXiEKmnML2zyoVPaq5/e9N9oufI8GZTVCIBPxrHWeqQ=="}
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 4 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[35m (0.2ms)[0m  [1m[35mBEGIN[0m
+  [1m[35m (0.1ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 9ms (ActiveRecord: 1.3ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 00:44:03 +0900
+Processing by GroupsController#index as HTML
+Completed 401 Unauthorized in 2ms (ActiveRecord: 0.0ms)
+
+
+Started GET "/users/sign_in" for ::1 at 2020-01-16 00:44:03 +0900
+Processing by Devise::SessionsController#new as HTML
+  Rendering devise/sessions/new.html.haml within layouts/application
+  Rendered devise/shared/_links.html.haml (1.9ms)
+  Rendered devise/sessions/new.html.haml within layouts/application (12.1ms)
+  Rendered layouts/_notifications.html.haml (2.3ms)
+Completed 200 OK in 49ms (Views: 47.6ms | ActiveRecord: 0.0ms)
+
+
+Started GET "/groups/7/messages" for ::1 at 2020-01-16 00:44:10 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"7"}
+Completed 401 Unauthorized in 1ms (ActiveRecord: 0.0ms)
+
+
+Started GET "/users/sign_in" for ::1 at 2020-01-16 00:44:10 +0900
+Processing by Devise::SessionsController#new as HTML
+  Rendering devise/sessions/new.html.haml within layouts/application
+  Rendered devise/shared/_links.html.haml (1.7ms)
+  Rendered devise/sessions/new.html.haml within layouts/application (12.4ms)
+  Rendered layouts/_notifications.html.haml (9.5ms)
+Completed 200 OK in 62ms (Views: 60.6ms | ActiveRecord: 0.0ms)
+
+
+Started POST "/users/sign_in" for ::1 at 2020-01-16 00:44:13 +0900
+Processing by Devise::SessionsController#create as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"j3/7QCvuITtEX7TM2UlTK4pE7tgv0Q2/nmJpIHvw6y1UiK8e0OsJnOfctbQ8ofxXrTIYNUzc6fMvW2hMPPvpwA==", "user"=>{"email"=>"", "password"=>"[FILTERED]"}, "commit"=>"Log in"}
+Completed 401 Unauthorized in 3ms (ActiveRecord: 0.0ms)
+
+
+Processing by Devise::SessionsController#new as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"j3/7QCvuITtEX7TM2UlTK4pE7tgv0Q2/nmJpIHvw6y1UiK8e0OsJnOfctbQ8ofxXrTIYNUzc6fMvW2hMPPvpwA==", "user"=>{"email"=>"", "password"=>"[FILTERED]"}, "commit"=>"Log in"}
+  Rendering devise/sessions/new.html.haml within layouts/application
+  Rendered devise/shared/_links.html.haml (1.6ms)
+  Rendered devise/sessions/new.html.haml within layouts/application (8.4ms)
+  Rendered layouts/_notifications.html.haml (2.5ms)
+Completed 200 OK in 45ms (Views: 44.3ms | ActiveRecord: 0.0ms)
+
+
+Started GET "/users/sign_up" for ::1 at 2020-01-16 00:44:20 +0900
+Processing by Devise::RegistrationsController#new as HTML
+  Rendering devise/registrations/new.html.haml within layouts/application
+  Rendered devise/shared/_links.html.haml (2.5ms)
+DEPRECATION WARNING: [Devise] `DeviseHelper.devise_error_messages!`
+is deprecated and it will be removed in the next major version.
+To customize the errors styles please run `rails g devise:views` and modify the
+`devise/shared/error_messages` partial.
+ (called from block in _app_views_devise_registrations_new_html_haml__861647045606944636_70250100730700 at /Users/choisdavid/projects/chat-space/app/views/devise/registrations/new.html.haml:9)
+  Rendered devise/registrations/new.html.haml within layouts/application (30.9ms)
+  Rendered layouts/_notifications.html.haml (1.5ms)
+Completed 200 OK in 70ms (Views: 68.6ms | ActiveRecord: 0.0ms)
+
+
+Started POST "/users" for ::1 at 2020-01-16 00:45:04 +0900
+Processing by Devise::RegistrationsController#create as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"fK3Y0hnLG6kIjGKpcC8su4RYX/SBnHrHgP60jH1PwlWnWoyM4s4zDqsPY9GVx4PHoy6pGeKRnosxx7XgOkTAuA==", "user"=>{"name"=>"chat0117", "email"=>"chat0117@gmail.com", "password"=>"[FILTERED]", "password_confirmation"=>"[FILTERED]"}, "commit"=>"Create Account"}
+  [1m[35m (0.2ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists (0.2ms)[0m  [1m[34mSELECT  1 AS one FROM `users` WHERE `users`.`email` = BINARY 'chat0117@gmail.com' LIMIT 1[0m
+  [1m[35mSQL (1.8ms)[0m  [1m[32mINSERT INTO `users` (`name`, `email`, `encrypted_password`, `created_at`, `updated_at`) VALUES ('chat0117', 'chat0117@gmail.com', '$2a$11$kcc09R7Mbqks08T5xRjeZukuSfbLhtIzr4/zW8dHUunz1/tVA7RYm', '2020-01-15 15:45:04', '2020-01-15 15:45:04')[0m
+  [1m[35m (1.0ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/groups/7/messages
+Completed 302 Found in 151ms (ActiveRecord: 3.2ms)
+
+
+Started GET "/groups/7/messages" for ::1 at 2020-01-16 00:45:04 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"7"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 7 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 5[0m
+  Rendered shared/_side_bar.html.haml (5.8ms)
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 7[0m
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7[0m
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 4[0m
+  Rendered collection of messages/_message.html.haml [16 times] (7.7ms)
+  Rendered messages/_main_chat.html.haml (19.5ms)
+  Rendered messages/index.html.haml within layouts/application (34.7ms)
+  Rendered layouts/_notifications.html.haml (2.0ms)
+Completed 200 OK in 101ms (Views: 92.0ms | ActiveRecord: 4.0ms)
+
+
+Started POST "/groups/7/messages" for ::1 at 2020-01-16 00:45:16 +0900
+Processing by MessagesController#create as JSON
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"UWL2xevsC5MmM9Rv7HU+C+YnUpREzGVDErS7VXgBSXaKlaKbEOkjNIWw1RcJnZF3wVGkeSfBgQ+jjbo5PwpLmw==", "message"=>{"content"=>"よろしくですね。"}, "group_id"=>"7"}
+  [1m[36mUser Load (1.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 7 LIMIT 1[0m
+  [1m[35m (1.4ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (2.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 LIMIT 1[0m
+  [1m[35mSQL (0.7ms)[0m  [1m[32mINSERT INTO `messages` (`content`, `group_id`, `user_id`, `created_at`, `updated_at`) VALUES ('よろしくですね。', 7, 5, '2020-01-15 15:45:16', '2020-01-15 15:45:16')[0m
+  [1m[35m (0.6ms)[0m  [1m[35mCOMMIT[0m
+  Rendering messages/create.json.jbuilder
+  Rendered messages/create.json.jbuilder (0.8ms)
+Completed 200 OK in 33ms (Views: 14.3ms | ActiveRecord: 6.5ms)
+
+
+Started GET "/groups/7/[object" for ::1 at 2020-01-16 00:45:16 +0900
+  
+ActionController::RoutingError (No route matches [GET] "/groups/7/[object"):
+  
+actionpack (5.0.7.2) lib/action_dispatch/middleware/debug_exceptions.rb:53:in `call'
+web-console (3.7.0) lib/web_console/middleware.rb:135:in `call_app'
+web-console (3.7.0) lib/web_console/middleware.rb:30:in `block in call'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `catch'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
+railties (5.0.7.2) lib/rails/rack/logger.rb:36:in `call_app'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `block in call'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `block in tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:26:in `tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `tagged'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `call'
+sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:13:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/request_id.rb:24:in `call'
+rack (2.0.7) lib/rack/method_override.rb:22:in `call'
+rack (2.0.7) lib/rack/runtime.rb:22:in `call'
+activesupport (5.0.7.2) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/executor.rb:12:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/static.rb:136:in `call'
+rack (2.0.7) lib/rack/sendfile.rb:111:in `call'
+railties (5.0.7.2) lib/rails/engine.rb:522:in `call'
+puma (3.12.1) lib/puma/configuration.rb:227:in `call'
+puma (3.12.1) lib/puma/server.rb:660:in `handle_request'
+puma (3.12.1) lib/puma/server.rb:474:in `process_client'
+puma (3.12.1) lib/puma/server.rb:334:in `block in run'
+puma (3.12.1) lib/puma/thread_pool.rb:135:in `block in spawn_thread'
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (1.1ms)
+  Rendered collection of /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/routes/_route.html.erb [27 times] (19.9ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/routes/_table.html.erb (2.6ms)
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (1.2ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (142.5ms)
+Started GET "/groups/new" for ::1 at 2020-01-16 00:45:25 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (7.8ms)
+  Rendered groups/new.html.haml within layouts/application (11.6ms)
+  Rendered layouts/_notifications.html.haml (1.6ms)
+Completed 200 OK in 42ms (Views: 37.9ms | ActiveRecord: 0.2ms)
+
+
+Started GET "/groups/7/messages" for ::1 at 2020-01-16 00:45:27 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"7"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 7 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 5[0m
+  Rendered shared/_side_bar.html.haml (5.7ms)
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 7[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` IN (4, 5)[0m
+  Rendered collection of messages/_message.html.haml [17 times] (5.6ms)
+  Rendered messages/_main_chat.html.haml (14.5ms)
+  Rendered messages/index.html.haml within layouts/application (29.5ms)
+  Rendered layouts/_notifications.html.haml (2.2ms)
+Completed 200 OK in 74ms (Views: 65.7ms | ActiveRecord: 1.9ms)
+
+
+Started GET "/users/5/edit" for ::1 at 2020-01-16 00:45:29 +0900
+Processing by UsersController#edit as HTML
+  Parameters: {"id"=>"5"}
+  [1m[36mUser Load (4.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/edit.html.haml within layouts/application
+  Rendered users/edit.html.haml within layouts/application (7.6ms)
+  Rendered layouts/_notifications.html.haml (1.5ms)
+Completed 200 OK in 55ms (Views: 46.1ms | ActiveRecord: 4.9ms)
+
+
+Started PATCH "/users/5" for ::1 at 2020-01-16 00:45:36 +0900
+Processing by UsersController#update as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"EtrXuLzt8JXBkcyReOjgDHtqWeo0itLTZl/jGgGeAQbJLYPmR+jYMmISzemdAE9wXByvB1eHNp/XZuJ2RpUD6w==", "user"=>{"name"=>"chat0117", "email"=>"chat0117@gmail.com"}, "commit"=>"Update", "id"=>"5"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[35m (0.1ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 4ms (ActiveRecord: 0.5ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 00:45:36 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 5[0m
+  Rendered shared/_side_bar.html.haml (5.0ms)
+  Rendered groups/index.html.haml within layouts/application (9.1ms)
+  Rendered layouts/_notifications.html.haml (3.9ms)
+Completed 200 OK in 70ms (Views: 65.3ms | ActiveRecord: 1.3ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 00:45:44 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (6.9ms)
+  Rendered groups/new.html.haml within layouts/application (10.5ms)
+  Rendered layouts/_notifications.html.haml (2.6ms)
+Completed 200 OK in 46ms (Views: 42.4ms | ActiveRecord: 0.2ms)
+
+
+Started GET "/users/5/edit" for ::1 at 2020-01-16 00:45:50 +0900
+Processing by UsersController#edit as HTML
+  Parameters: {"id"=>"5"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/edit.html.haml within layouts/application
+  Rendered users/edit.html.haml within layouts/application (8.1ms)
+  Rendered layouts/_notifications.html.haml (1.6ms)
+Completed 200 OK in 43ms (Views: 39.6ms | ActiveRecord: 0.3ms)
+
+
+Started GET "/groups/7/edit" for ::1 at 2020-01-16 00:46:08 +0900
+Processing by GroupsController#edit as HTML
+  Parameters: {"id"=>"7"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 7 LIMIT 1[0m
+  Rendering groups/edit.html.haml within layouts/application
+  Rendered groups/_form.html.haml (7.0ms)
+  Rendered groups/edit.html.haml within layouts/application (9.9ms)
+  Rendered layouts/_notifications.html.haml (2.0ms)
+Completed 200 OK in 40ms (Views: 36.6ms | ActiveRecord: 0.4ms)
+
+
+Started GET "/users?keyword=c" for ::1 at 2020-01-16 00:46:12 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"c"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%c%') AND (`users`.`id` != 5) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (1.7ms)
+Completed 200 OK in 14ms (Views: 10.7ms | ActiveRecord: 0.5ms)
+
+
+Started GET "/users?keyword=ch" for ::1 at 2020-01-16 00:46:12 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"ch"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%ch%') AND (`users`.`id` != 5) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (1.2ms)
+Completed 200 OK in 15ms (Views: 11.5ms | ActiveRecord: 0.5ms)
+
+
+Started GET "/users?keyword=cha" for ::1 at 2020-01-16 00:46:13 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"cha"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%cha%') AND (`users`.`id` != 5) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (2.5ms)
+Completed 200 OK in 16ms (Views: 11.8ms | ActiveRecord: 1.2ms)
+
+
+Started GET "/users?keyword=chat" for ::1 at 2020-01-16 00:46:13 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"chat"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%chat%') AND (`users`.`id` != 5) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (1.7ms)
+Completed 200 OK in 19ms (Views: 15.3ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/users?keyword=chat0" for ::1 at 2020-01-16 00:46:15 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"chat0"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (7.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%chat0%') AND (`users`.`id` != 5) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (8.8ms)
+Completed 200 OK in 30ms (Views: 17.8ms | ActiveRecord: 7.8ms)
+
+
+Started GET "/users?keyword=chat01" for ::1 at 2020-01-16 00:46:17 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"chat01"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%chat01%') AND (`users`.`id` != 5) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (1.1ms)
+Completed 200 OK in 15ms (Views: 10.6ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/users?keyword=chat011" for ::1 at 2020-01-16 00:46:17 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"chat011"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%chat011%') AND (`users`.`id` != 5) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (2.0ms)
+Completed 200 OK in 15ms (Views: 11.3ms | ActiveRecord: 1.2ms)
+
+
+Started GET "/users?keyword=chat0117" for ::1 at 2020-01-16 00:46:19 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"chat0117"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%chat0117%') AND (`users`.`id` != 5) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (1.1ms)
+Completed 200 OK in 15ms (Views: 11.2ms | ActiveRecord: 0.5ms)
+
+
+Started GET "/users?keyword=chat011" for ::1 at 2020-01-16 00:46:21 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"chat011"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%chat011%') AND (`users`.`id` != 5) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (1.5ms)
+Completed 200 OK in 20ms (Views: 10.6ms | ActiveRecord: 0.5ms)
+
+
+Started GET "/users?keyword=chat0116" for ::1 at 2020-01-16 00:46:21 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"chat0116"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%chat0116%') AND (`users`.`id` != 5) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (1.3ms)
+Completed 200 OK in 15ms (Views: 11.8ms | ActiveRecord: 0.5ms)
+
+
+Started PATCH "/groups/7" for ::1 at 2020-01-16 00:46:26 +0900
+Processing by GroupsController#update as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"U+a+aJ3Wm1C/+pfqd+HvXMmFafiBpDKxT9PJaaLcoamIEeo2ZtOz9xx5lpKSCUAg7vOfFeKp1v3+6sgF5dejRA==", "group"=>{"name"=>"chatgroup0110", "user_ids"=>["4"]}, "commit"=>"更新する", "id"=>"7"}
+  [1m[36mUser Load (3.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (2.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 7 LIMIT 1[0m
+  [1m[35m (1.3ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 4[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 7[0m
+  [1m[35mSQL (0.2ms)[0m  [1m[31mDELETE FROM `group_users` WHERE `group_users`.`group_id` = 7 AND `group_users`.`user_id` = 3[0m
+  [1m[35mSQL (0.4ms)[0m  [1m[32mINSERT INTO `group_users` (`group_id`, `user_id`, `created_at`, `updated_at`) VALUES (7, 4, '2020-01-15 15:46:26', '2020-01-15 15:46:26')[0m
+  [1m[36mGroup Exists (1.0ms)[0m  [1m[34mSELECT  1 AS one FROM `groups` WHERE `groups`.`name` = BINARY 'chatgroup0110' AND (`groups`.`id` != 7) LIMIT 1[0m
+  [1m[35m (0.6ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/groups/7/messages
+Completed 302 Found in 24ms (ActiveRecord: 9.9ms)
+
+
+Started GET "/groups/7/messages" for ::1 at 2020-01-16 00:46:26 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"7"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 7 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 5[0m
+  Rendered shared/_side_bar.html.haml (4.8ms)
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 7[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` IN (4, 5)[0m
+  Rendered collection of messages/_message.html.haml [17 times] (6.4ms)
+  Rendered messages/_main_chat.html.haml (15.5ms)
+  Rendered messages/index.html.haml within layouts/application (29.4ms)
+  Rendered layouts/_notifications.html.haml (1.9ms)
+Completed 200 OK in 66ms (Views: 60.8ms | ActiveRecord: 2.2ms)
+
+
+Started GET "/users/5/edit" for ::1 at 2020-01-16 00:46:48 +0900
+Processing by UsersController#edit as HTML
+  Parameters: {"id"=>"5"}
+  [1m[36mUser Load (1.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/edit.html.haml within layouts/application
+  Rendered users/edit.html.haml within layouts/application (10.0ms)
+  Rendered layouts/_notifications.html.haml (3.0ms)
+Completed 200 OK in 59ms (Views: 53.5ms | ActiveRecord: 1.5ms)
+
+
+Started GET "/groups/7/messages" for ::1 at 2020-01-16 00:46:52 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"7"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 7 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 5[0m
+  Rendered shared/_side_bar.html.haml (9.6ms)
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 7[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 7[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` IN (4, 5)[0m
+  Rendered collection of messages/_message.html.haml [17 times] (6.5ms)
+  Rendered messages/_main_chat.html.haml (17.3ms)
+  Rendered messages/index.html.haml within layouts/application (37.8ms)
+  Rendered layouts/_notifications.html.haml (3.1ms)
+Completed 200 OK in 77ms (Views: 69.6ms | ActiveRecord: 1.6ms)
+
+
+Started GET "/users/sign_in" for ::1 at 2020-01-16 00:47:05 +0900
+Processing by Devise::SessionsController#new as HTML
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+Redirected to http://localhost:3000/
+Filter chain halted as :require_no_authentication rendered or redirected
+Completed 302 Found in 3ms (ActiveRecord: 0.3ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 00:47:25 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (6.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (4.4ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 5[0m
+  Rendered shared/_side_bar.html.haml (34.8ms)
+  Rendered groups/index.html.haml within layouts/application (42.9ms)
+  Rendered layouts/_notifications.html.haml (1.5ms)
+Completed 200 OK in 103ms (Views: 87.1ms | ActiveRecord: 10.5ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 00:47:35 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (8.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 5[0m
+  Rendered shared/_side_bar.html.haml (9.1ms)
+  Rendered groups/index.html.haml within layouts/application (12.9ms)
+  Rendered layouts/_notifications.html.haml (3.0ms)
+Completed 200 OK in 80ms (Views: 67.4ms | ActiveRecord: 9.0ms)
+
+
+Started GET "/users/5/edit" for ::1 at 2020-01-16 00:47:38 +0900
+Processing by UsersController#edit as HTML
+  Parameters: {"id"=>"5"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/edit.html.haml within layouts/application
+  Rendered users/edit.html.haml within layouts/application (6.1ms)
+  Rendered layouts/_notifications.html.haml (1.5ms)
+Completed 200 OK in 39ms (Views: 34.7ms | ActiveRecord: 0.3ms)
+
+
+Started PATCH "/users/5" for ::1 at 2020-01-16 00:47:40 +0900
+Processing by UsersController#update as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"fRFb2Atjt8dak8oxfwSngwdVCgAP474chWKMIY2Z/qGm5g+G8GafYPkQy0ma7Aj/ICP87WzuWlA0W41NypL8TA==", "user"=>{"name"=>"chat0117", "email"=>"chat0117@gmail.com"}, "commit"=>"Update", "id"=>"5"}
+  [1m[36mUser Load (5.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[35m (0.1ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 10ms (ActiveRecord: 6.1ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 00:47:40 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (2.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 5[0m
+  Rendered shared/_side_bar.html.haml (5.3ms)
+  Rendered groups/index.html.haml within layouts/application (10.7ms)
+  Rendered layouts/_notifications.html.haml (2.1ms)
+Completed 200 OK in 47ms (Views: 40.2ms | ActiveRecord: 2.7ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 00:47:44 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (2.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (7.3ms)
+  Rendered groups/new.html.haml within layouts/application (11.2ms)
+  Rendered layouts/_notifications.html.haml (2.3ms)
+Completed 200 OK in 56ms (Views: 48.3ms | ActiveRecord: 2.0ms)
+
+
+Started GET "/users?keyword=c" for ::1 at 2020-01-16 00:47:57 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"c"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%c%') AND (`users`.`id` != 5) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (1.2ms)
+Completed 200 OK in 14ms (Views: 10.4ms | ActiveRecord: 0.5ms)
+
+
+Started POST "/groups" for ::1 at 2020-01-16 00:48:08 +0900
+Processing by GroupsController#create as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"4CFas9FUyQEyh02wcwgdlRweZPuhGd+eWjUl5HZtI+w71g7tKlHhppEETMiW4LLpO2iSFsIUO9LrDCSIMWYhAQ==", "group"=>{"name"=>"chatgoup0117", "user_ids"=>["1", "3"]}, "commit"=>"登録する"}
+  [1m[36mUser Load (5.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` IN (1, 3)[0m
+  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mGroup Exists (2.2ms)[0m  [1m[34mSELECT  1 AS one FROM `groups` WHERE `groups`.`name` = BINARY 'chatgoup0117' LIMIT 1[0m
+  [1m[35mSQL (2.0ms)[0m  [1m[32mINSERT INTO `groups` (`name`, `created_at`, `updated_at`) VALUES ('chatgoup0117', '2020-01-15 15:48:09', '2020-01-15 15:48:09')[0m
+  [1m[35mSQL (0.8ms)[0m  [1m[32mINSERT INTO `group_users` (`group_id`, `user_id`, `created_at`, `updated_at`) VALUES (12, 1, '2020-01-15 15:48:09', '2020-01-15 15:48:09')[0m
+  [1m[35mSQL (1.2ms)[0m  [1m[32mINSERT INTO `group_users` (`group_id`, `user_id`, `created_at`, `updated_at`) VALUES (12, 3, '2020-01-15 15:48:09', '2020-01-15 15:48:09')[0m
+  [1m[35m (0.6ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 25ms (ActiveRecord: 12.9ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 00:48:09 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 5[0m
+  Rendered shared/_side_bar.html.haml (7.8ms)
+  Rendered groups/index.html.haml within layouts/application (10.5ms)
+  Rendered layouts/_notifications.html.haml (1.4ms)
+Completed 200 OK in 42ms (Views: 37.4ms | ActiveRecord: 1.2ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 00:48:18 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (4.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (10.7ms)
+  Rendered groups/new.html.haml within layouts/application (15.7ms)
+  Rendered layouts/_notifications.html.haml (1.7ms)
+Completed 200 OK in 66ms (Views: 55.2ms | ActiveRecord: 4.8ms)
+
+
+Started GET "/users/5/edit" for ::1 at 2020-01-16 00:48:22 +0900
+Processing by UsersController#edit as HTML
+  Parameters: {"id"=>"5"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/edit.html.haml within layouts/application
+  Rendered users/edit.html.haml within layouts/application (5.5ms)
+  Rendered layouts/_notifications.html.haml (1.4ms)
+Completed 200 OK in 37ms (Views: 32.7ms | ActiveRecord: 0.4ms)
+
+
+Started PATCH "/users/5" for ::1 at 2020-01-16 00:48:30 +0900
+Processing by UsersController#update as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"jKG7HkPuYFnJ7MxqWGgO5z/9asN2gI+Vqfj+jPbhDBVXVu9AuOtI/mpvzRK9gKGbGIucLhWNa9kYwf/gseoO+A==", "user"=>{"name"=>"chat0116", "email"=>"chat0117@gmail.com"}, "commit"=>"Update", "id"=>"5"}
+  [1m[36mUser Load (16.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[35m (2.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[35mSQL (4.3ms)[0m  [1m[33mUPDATE `users` SET `name` = 'chat0116', `updated_at` = '2020-01-15 15:48:30' WHERE `users`.`id` = 5[0m
+  [1m[35m (2.5ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 31ms (ActiveRecord: 25.2ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 00:48:30 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 5[0m
+  Rendered shared/_side_bar.html.haml (8.3ms)
+  Rendered groups/index.html.haml within layouts/application (13.1ms)
+  Rendered layouts/_notifications.html.haml (1.9ms)
+Completed 200 OK in 56ms (Views: 50.5ms | ActiveRecord: 1.5ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 00:48:42 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (6.6ms)
+  Rendered groups/new.html.haml within layouts/application (14.8ms)
+  Rendered layouts/_notifications.html.haml (1.5ms)
+Completed 200 OK in 50ms (Views: 44.6ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/users?keyword=c" for ::1 at 2020-01-16 00:48:48 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"c"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%c%') AND (`users`.`id` != 5) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (1.5ms)
+Completed 200 OK in 15ms (Views: 11.2ms | ActiveRecord: 0.5ms)
+
+
+Started POST "/groups" for ::1 at 2020-01-16 00:49:01 +0900
+Processing by GroupsController#create as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"FMtMZVfWvxxLgC+RFtUnzgYxIEpkrBZfO5wvYB0KjWbPPBg7rNOXu+gDLunzPYiyIUfWpweh8hOKpS4MWgGPiw==", "group"=>{"name"=>"cha-cha", "user_ids"=>["1", "2"]}, "commit"=>"登録する"}
+  [1m[36mUser Load (8.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` IN (1, 2)[0m
+  [1m[35m (3.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mGroup Exists (0.3ms)[0m  [1m[34mSELECT  1 AS one FROM `groups` WHERE `groups`.`name` = BINARY 'cha-cha' LIMIT 1[0m
+  [1m[35m (2.9ms)[0m  [1m[31mROLLBACK[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (6.5ms)
+  Rendered groups/new.html.haml within layouts/application (10.3ms)
+  Rendered layouts/_notifications.html.haml (1.4ms)
+Completed 200 OK in 64ms (Views: 38.8ms | ActiveRecord: 15.2ms)
+
+
+Started POST "/groups" for ::1 at 2020-01-16 00:49:15 +0900
+Processing by GroupsController#create as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"XZ1ab33OIOTRhMqw8UScj1f9vsI/2hIVS+fQHVvu2BiGag4xhssIQ3IHy8gUrDPzcItIL1zX9ln63tFxHOXa9Q==", "group"=>{"name"=>"chat"}, "commit"=>"登録する"}
+  [1m[36mUser Load (9.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[35m (1.5ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mGroup Exists (0.3ms)[0m  [1m[34mSELECT  1 AS one FROM `groups` WHERE `groups`.`name` = BINARY 'chat' LIMIT 1[0m
+  [1m[35mSQL (0.7ms)[0m  [1m[32mINSERT INTO `groups` (`name`, `created_at`, `updated_at`) VALUES ('chat', '2020-01-15 15:49:15', '2020-01-15 15:49:15')[0m
+  [1m[35m (1.2ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 19ms (ActiveRecord: 13.3ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 00:49:15 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 5[0m
+  Rendered shared/_side_bar.html.haml (5.3ms)
+  Rendered groups/index.html.haml within layouts/application (9.9ms)
+  Rendered layouts/_notifications.html.haml (1.6ms)
+Completed 200 OK in 47ms (Views: 40.2ms | ActiveRecord: 1.4ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 00:49:20 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (8.8ms)
+  Rendered groups/new.html.haml within layouts/application (12.8ms)
+  Rendered layouts/_notifications.html.haml (1.9ms)
+Completed 200 OK in 57ms (Views: 49.7ms | ActiveRecord: 0.9ms)
+
+
+Started GET "/users/5/edit" for ::1 at 2020-01-16 00:49:25 +0900
+Processing by UsersController#edit as HTML
+  Parameters: {"id"=>"5"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/edit.html.haml within layouts/application
+  Rendered users/edit.html.haml within layouts/application (13.0ms)
+  Rendered layouts/_notifications.html.haml (1.4ms)
+Completed 200 OK in 41ms (Views: 38.0ms | ActiveRecord: 0.3ms)
+
+
+Started DELETE "/users/sign_out" for ::1 at 2020-01-16 00:49:30 +0900
+Processing by Devise::SessionsController#destroy as HTML
+  Parameters: {"authenticity_token"=>"1vWe9tyJBxk6T16MzprFSIXAU1KT0SuknonFAk+8UeYNAsqoJ4wvvpnMX/Qrcmo0oralv/Dcz+gvsMRuCLdTCw=="}
+  [1m[36mUser Load (2.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 5 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[35m (0.3ms)[0m  [1m[35mBEGIN[0m
+  [1m[35m (0.2ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 7ms (ActiveRecord: 2.4ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 00:49:30 +0900
+Processing by GroupsController#index as HTML
+Completed 401 Unauthorized in 1ms (ActiveRecord: 0.0ms)
+
+
+Started GET "/users/sign_in" for ::1 at 2020-01-16 00:49:30 +0900
+Processing by Devise::SessionsController#new as HTML
+  Rendering devise/sessions/new.html.haml within layouts/application
+  Rendered devise/shared/_links.html.haml (2.8ms)
+  Rendered devise/sessions/new.html.haml within layouts/application (14.4ms)
+  Rendered layouts/_notifications.html.haml (1.9ms)
+Completed 200 OK in 60ms (Views: 58.7ms | ActiveRecord: 0.0ms)
+
+
+Started GET "/users/sign_up" for ::1 at 2020-01-16 00:49:34 +0900
+Processing by Devise::RegistrationsController#new as HTML
+  Rendering devise/registrations/new.html.haml within layouts/application
+  Rendered devise/shared/_links.html.haml (1.6ms)
+DEPRECATION WARNING: [Devise] `DeviseHelper.devise_error_messages!`
+is deprecated and it will be removed in the next major version.
+To customize the errors styles please run `rails g devise:views` and modify the
+`devise/shared/error_messages` partial.
+ (called from block in _app_views_devise_registrations_new_html_haml__861647045606944636_70250095148700 at /Users/choisdavid/projects/chat-space/app/views/devise/registrations/new.html.haml:9)
+  Rendered devise/registrations/new.html.haml within layouts/application (10.6ms)
+  Rendered layouts/_notifications.html.haml (2.1ms)
+Completed 200 OK in 48ms (Views: 47.0ms | ActiveRecord: 0.0ms)
+
+
+Started POST "/users" for ::1 at 2020-01-16 00:50:05 +0900
+Processing by Devise::RegistrationsController#create as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"cDoJ6Juu9erykqLBeXDBH7+GGZ3uQm19zrBOqdIwPr3XVm9TWeQw2EtN6msUtfRC8rpydRMijBlZrEIfB5Ne+w==", "user"=>{"name"=>"chat0118", "email"=>"chat0118@gmail.com", "password"=>"[FILTERED]", "password_confirmation"=>"[FILTERED]"}, "commit"=>"Create Account"}
+  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists (0.2ms)[0m  [1m[34mSELECT  1 AS one FROM `users` WHERE `users`.`email` = BINARY 'chat0118@gmail.com' LIMIT 1[0m
+  [1m[35mSQL (0.3ms)[0m  [1m[32mINSERT INTO `users` (`name`, `email`, `encrypted_password`, `created_at`, `updated_at`) VALUES ('chat0118', 'chat0118@gmail.com', '$2a$11$KJb5HMNFhjedJLsSsmSdqeLm7qLB3BIKGC5FVfkWuAjW4uGcghSmG', '2020-01-15 15:50:05', '2020-01-15 15:50:05')[0m
+  [1m[35m (2.6ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 132ms (ActiveRecord: 3.2ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 00:50:05 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 6[0m
+  Rendered shared/_side_bar.html.haml (4.8ms)
+  Rendered groups/index.html.haml within layouts/application (9.6ms)
+  Rendered layouts/_notifications.html.haml (1.5ms)
+Completed 200 OK in 37ms (Views: 34.8ms | ActiveRecord: 0.5ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 00:50:10 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (1.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (8.6ms)
+  Rendered groups/new.html.haml within layouts/application (11.7ms)
+  Rendered layouts/_notifications.html.haml (1.5ms)
+Completed 200 OK in 52ms (Views: 44.2ms | ActiveRecord: 1.5ms)
+
+
+Started GET "/users?keyword=" for ::1 at 2020-01-16 00:50:19 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>""}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  Rendered users/index.json.jbuilder (0.4ms)
+Completed 200 OK in 37ms (Views: 19.5ms | ActiveRecord: 0.5ms)
+
+
+Started GET "/users?keyword=c" for ::1 at 2020-01-16 00:50:21 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"c"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%c%') AND (`users`.`id` != 6) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (1.3ms)
+Completed 200 OK in 13ms (Views: 10.2ms | ActiveRecord: 0.4ms)
+
+
+Started POST "/groups" for ::1 at 2020-01-16 00:50:30 +0900
+Processing by GroupsController#create as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"A2ThA/SbQOS0DftlLDXzHhNPFa6o9Ag8t+1jvohhNU6kCIe4NtGF1g3Ss89B8MZDXnN+RlWU6Vgg8W8IXcJVCA==", "group"=>{"name"=>"chat0118", "user_ids"=>["1", "2", "4"]}, "commit"=>"登録する"}
+  [1m[36mUser Load (7.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` IN (1, 2, 4)[0m
+  [1m[35m (9.8ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mGroup Exists (1.8ms)[0m  [1m[34mSELECT  1 AS one FROM `groups` WHERE `groups`.`name` = BINARY 'chat0118' LIMIT 1[0m
+  [1m[35mSQL (2.8ms)[0m  [1m[32mINSERT INTO `groups` (`name`, `created_at`, `updated_at`) VALUES ('chat0118', '2020-01-15 15:50:30', '2020-01-15 15:50:30')[0m
+  [1m[35mSQL (1.9ms)[0m  [1m[32mINSERT INTO `group_users` (`group_id`, `user_id`, `created_at`, `updated_at`) VALUES (14, 1, '2020-01-15 15:50:30', '2020-01-15 15:50:30')[0m
+  [1m[35mSQL (0.8ms)[0m  [1m[32mINSERT INTO `group_users` (`group_id`, `user_id`, `created_at`, `updated_at`) VALUES (14, 2, '2020-01-15 15:50:30', '2020-01-15 15:50:30')[0m
+  [1m[35mSQL (0.2ms)[0m  [1m[32mINSERT INTO `group_users` (`group_id`, `user_id`, `created_at`, `updated_at`) VALUES (14, 4, '2020-01-15 15:50:30', '2020-01-15 15:50:30')[0m
+  [1m[35m (0.4ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 45ms (ActiveRecord: 26.4ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 00:50:30 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 6[0m
+  Rendered shared/_side_bar.html.haml (4.4ms)
+  Rendered groups/index.html.haml within layouts/application (8.2ms)
+  Rendered layouts/_notifications.html.haml (1.8ms)
+Completed 200 OK in 38ms (Views: 35.5ms | ActiveRecord: 0.5ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 00:50:41 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (11.4ms)
+  Rendered groups/new.html.haml within layouts/application (20.1ms)
+  Rendered layouts/_notifications.html.haml (2.5ms)
+Completed 200 OK in 65ms (Views: 61.1ms | ActiveRecord: 0.2ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 10:44:36 +0900
+  [1m[36mActiveRecord::SchemaMigration Load (8.3ms)[0m  [1m[34mSELECT `schema_migrations`.* FROM `schema_migrations`[0m
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (5.7ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 6[0m
+  Rendered shared/_side_bar.html.haml (61.0ms)
+  Rendered groups/index.html.haml within layouts/application (73.0ms)
+  Rendered layouts/_notifications.html.haml (1.4ms)
+Completed 200 OK in 391ms (Views: 355.2ms | ActiveRecord: 18.0ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 10:44:43 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 6[0m
+  Rendered shared/_side_bar.html.haml (4.1ms)
+  Rendered groups/index.html.haml within layouts/application (7.2ms)
+  Rendered layouts/_notifications.html.haml (2.7ms)
+Completed 200 OK in 43ms (Views: 39.1ms | ActiveRecord: 0.9ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 10:44:48 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (1003.6ms)
+  Rendered groups/new.html.haml within layouts/application (1007.2ms)
+  Rendered layouts/_notifications.html.haml (1.3ms)
+Completed 200 OK in 1057ms (Views: 1038.9ms | ActiveRecord: 1.4ms)
+
+
+Started GET "/users?keyword=" for ::1 at 2020-01-16 10:45:00 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>""}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  Rendered users/index.json.jbuilder (0.5ms)
+Completed 200 OK in 37ms (Views: 20.0ms | ActiveRecord: 0.2ms)
+
+
+Started GET "/users?keyword=c" for ::1 at 2020-01-16 10:45:01 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"c"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%c%') AND (`users`.`id` != 6) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (1.8ms)
+Completed 200 OK in 15ms (Views: 11.3ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/users?keyword=chat0116" for ::1 at 2020-01-16 10:45:03 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"chat0116"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%chat0116%') AND (`users`.`id` != 6) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (1.0ms)
+Completed 200 OK in 13ms (Views: 10.3ms | ActiveRecord: 0.4ms)
+
+
+Started POST "/groups" for ::1 at 2020-01-16 10:45:07 +0900
+Processing by GroupsController#create as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"N7Q+XUzJW6iWhlixsi2tfOibUWajB1s2WVruY6TKtAKQ2FjmjoOemi9ZEBvf6Jghpac6jl5nulLORuLVcWnURA==", "group"=>{"name"=>"chatagain", "user_ids"=>["4"]}, "commit"=>"登録する"}
+  [1m[36mUser Load (1.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 4[0m
+  [1m[35m (4.2ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mGroup Exists (28.2ms)[0m  [1m[34mSELECT  1 AS one FROM `groups` WHERE `groups`.`name` = BINARY 'chatagain' LIMIT 1[0m
+  [1m[35mSQL (3.3ms)[0m  [1m[32mINSERT INTO `groups` (`name`, `created_at`, `updated_at`) VALUES ('chatagain', '2020-01-16 01:45:07', '2020-01-16 01:45:07')[0m
+  [1m[35mSQL (0.7ms)[0m  [1m[32mINSERT INTO `group_users` (`group_id`, `user_id`, `created_at`, `updated_at`) VALUES (15, 4, '2020-01-16 01:45:07', '2020-01-16 01:45:07')[0m
+  [1m[35m (1.6ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 51ms (ActiveRecord: 39.9ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 10:45:07 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 6[0m
+  Rendered shared/_side_bar.html.haml (8.4ms)
+  Rendered groups/index.html.haml within layouts/application (12.1ms)
+  Rendered layouts/_notifications.html.haml (1.5ms)
+Completed 200 OK in 60ms (Views: 56.8ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/users/6/edit" for ::1 at 2020-01-16 10:45:14 +0900
+Processing by UsersController#edit as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/edit.html.haml within layouts/application
+  Rendered users/edit.html.haml within layouts/application (6.3ms)
+  Rendered layouts/_notifications.html.haml (2.0ms)
+Completed 200 OK in 42ms (Views: 37.0ms | ActiveRecord: 0.7ms)
+
+
+Started PATCH "/users/6" for ::1 at 2020-01-16 10:45:17 +0900
+Processing by UsersController#update as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"LKVa/BWqOXv/0/vR6wn/s2q53k4a8O38XlOzf6cLULiLyTxH1+D8SUYMs3uGzMruJ4W1pueQDJjJT7/Jcqgw/g==", "user"=>{"name"=>"chat0118", "email"=>"chat0118@gmail.com"}, "commit"=>"Update", "id"=>"6"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[35m (5.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[35m (0.1ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 9ms (ActiveRecord: 5.4ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 10:45:17 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 6[0m
+  Rendered shared/_side_bar.html.haml (5.6ms)
+  Rendered groups/index.html.haml within layouts/application (9.7ms)
+  Rendered layouts/_notifications.html.haml (2.6ms)
+Completed 200 OK in 46ms (Views: 41.1ms | ActiveRecord: 1.3ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 10:45:34 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (5.5ms)
+  Rendered groups/new.html.haml within layouts/application (8.1ms)
+  Rendered layouts/_notifications.html.haml (1.3ms)
+Completed 200 OK in 36ms (Views: 31.4ms | ActiveRecord: 0.4ms)
+
+
+Started GET "/users/6/edit" for ::1 at 2020-01-16 10:45:40 +0900
+Processing by UsersController#edit as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/edit.html.haml within layouts/application
+  Rendered users/edit.html.haml within layouts/application (4.5ms)
+  Rendered layouts/_notifications.html.haml (1.8ms)
+Completed 200 OK in 30ms (Views: 26.7ms | ActiveRecord: 0.3ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 10:45:42 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 6[0m
+  Rendered shared/_side_bar.html.haml (5.6ms)
+  Rendered groups/index.html.haml within layouts/application (8.9ms)
+  Rendered layouts/_notifications.html.haml (1.5ms)
+Completed 200 OK in 33ms (Views: 30.3ms | ActiveRecord: 0.5ms)
+
+
+Started GET "/users/6/edit" for ::1 at 2020-01-16 10:45:44 +0900
+Processing by UsersController#edit as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/edit.html.haml within layouts/application
+  Rendered users/edit.html.haml within layouts/application (6.1ms)
+  Rendered layouts/_notifications.html.haml (1.7ms)
+Completed 200 OK in 40ms (Views: 36.2ms | ActiveRecord: 0.3ms)
+
+
+Started DELETE "/users/sign_out" for ::1 at 2020-01-16 10:45:52 +0900
+Processing by Devise::SessionsController#destroy as HTML
+  Parameters: {"authenticity_token"=>"ja5DasYLLbD+FN6l2qeHOD0HDKJdVhi2PoFn2P7aT+gqwiXRBEHogkfLlg+3YrJlcDtnSqA2+dKpnWtuK3kvrg=="}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 6 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[35m (0.1ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 8ms (ActiveRecord: 0.6ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 10:45:52 +0900
+Processing by GroupsController#index as HTML
+Completed 401 Unauthorized in 4ms (ActiveRecord: 0.0ms)
+
+
+Started GET "/users/sign_in" for ::1 at 2020-01-16 10:45:52 +0900
+Processing by Devise::SessionsController#new as HTML
+  Rendering devise/sessions/new.html.haml within layouts/application
+  Rendered devise/shared/_links.html.haml (1.6ms)
+  Rendered devise/sessions/new.html.haml within layouts/application (8.8ms)
+  Rendered layouts/_notifications.html.haml (1.4ms)
+Completed 200 OK in 36ms (Views: 34.8ms | ActiveRecord: 0.0ms)
+
+
+Started GET "/users/sign_up" for ::1 at 2020-01-16 10:46:10 +0900
+Processing by Devise::RegistrationsController#new as HTML
+  Rendering devise/registrations/new.html.haml within layouts/application
+  Rendered devise/shared/_links.html.haml (1.5ms)
+DEPRECATION WARNING: [Devise] `DeviseHelper.devise_error_messages!`
+is deprecated and it will be removed in the next major version.
+To customize the errors styles please run `rails g devise:views` and modify the
+`devise/shared/error_messages` partial.
+ (called from block in _app_views_devise_registrations_new_html_haml___68481421368606785_70332930572340 at /Users/choisdavid/projects/chat-space/app/views/devise/registrations/new.html.haml:9)
+  Rendered devise/registrations/new.html.haml within layouts/application (9.3ms)
+  Rendered layouts/_notifications.html.haml (1.3ms)
+Completed 200 OK in 37ms (Views: 36.4ms | ActiveRecord: 0.0ms)
+
+
+Started POST "/users" for ::1 at 2020-01-16 10:46:45 +0900
+Processing by Devise::RegistrationsController#create as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"CC61cZElHtFbZQnSLzzUQRce0CDA0aYA/WrVVqPITpVbuFuPfVX+5IFaKQFo7di1vu72kRo5fjkKHtC6IPBWDQ==", "user"=>{"name"=>"chat0116", "email"=>"chat0116@gmail.com", "password"=>"[FILTERED]", "password_confirmation"=>"[FILTERED]"}, "commit"=>"Create Account"}
+  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists (0.2ms)[0m  [1m[34mSELECT  1 AS one FROM `users` WHERE `users`.`email` = BINARY 'chat0116@gmail.com' LIMIT 1[0m
+  [1m[35m (1.7ms)[0m  [1m[31mROLLBACK[0m
+  Rendering devise/registrations/new.html.haml within layouts/application
+  Rendered devise/shared/_links.html.haml (1.8ms)
+DEPRECATION WARNING: [Devise] `DeviseHelper.devise_error_messages!`
+is deprecated and it will be removed in the next major version.
+To customize the errors styles please run `rails g devise:views` and modify the
+`devise/shared/error_messages` partial.
+ (called from block in _app_views_devise_registrations_new_html_haml___68481421368606785_70332930350080 at /Users/choisdavid/projects/chat-space/app/views/devise/registrations/new.html.haml:9)
+  Rendered devise/shared/_error_messages.html.haml (2.8ms)
+  Rendered devise/registrations/new.html.haml within layouts/application (14.1ms)
+  Rendered layouts/_notifications.html.haml (1.3ms)
+Completed 200 OK in 172ms (Views: 37.1ms | ActiveRecord: 2.1ms)
+
+
+Started POST "/users" for ::1 at 2020-01-16 10:47:18 +0900
+Processing by Devise::RegistrationsController#create as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"Y1MFGWE7uOFCHJBC0IIn4kOjK3w3+GrjmiH/5Zf7KxkwxevnjUtY1JgjsJGXUysW6lMNze0QstptVfoJFMMzgQ==", "user"=>{"name"=>"chat0120", "email"=>"chat0120@gmail.com", "password"=>"[FILTERED]", "password_confirmation"=>"[FILTERED]"}, "commit"=>"Create Account"}
+  [1m[35m (0.2ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists (0.9ms)[0m  [1m[34mSELECT  1 AS one FROM `users` WHERE `users`.`email` = BINARY 'chat0120@gmail.com' LIMIT 1[0m
+  [1m[35mSQL (1.9ms)[0m  [1m[32mINSERT INTO `users` (`name`, `email`, `encrypted_password`, `created_at`, `updated_at`) VALUES ('chat0120', 'chat0120@gmail.com', '$2a$11$i8MzswTHpVVwRXy3jZKL5uIrPW.pxsf2QFEek4R/35lrnAFqkV9GK', '2020-01-16 01:47:19', '2020-01-16 01:47:19')[0m
+  [1m[35m (0.7ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 127ms (ActiveRecord: 3.6ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 10:47:19 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 7[0m
+  Rendered shared/_side_bar.html.haml (4.1ms)
+  Rendered groups/index.html.haml within layouts/application (7.1ms)
+  Rendered layouts/_notifications.html.haml (1.3ms)
+Completed 200 OK in 33ms (Views: 30.2ms | ActiveRecord: 0.4ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 10:47:29 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 7[0m
+  Rendered shared/_side_bar.html.haml (4.8ms)
+  Rendered groups/index.html.haml within layouts/application (8.9ms)
+  Rendered layouts/_notifications.html.haml (1.9ms)
+Completed 200 OK in 38ms (Views: 34.0ms | ActiveRecord: 0.5ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 10:47:35 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (6.7ms)
+  Rendered groups/new.html.haml within layouts/application (9.5ms)
+  Rendered layouts/_notifications.html.haml (1.3ms)
+Completed 200 OK in 40ms (Views: 35.4ms | ActiveRecord: 0.4ms)
+
+
+Started GET "/users/7/edit" for ::1 at 2020-01-16 10:47:44 +0900
+Processing by UsersController#edit as HTML
+  Parameters: {"id"=>"7"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/edit.html.haml within layouts/application
+  Rendered users/edit.html.haml within layouts/application (4.5ms)
+  Rendered layouts/_notifications.html.haml (1.6ms)
+Completed 200 OK in 36ms (Views: 31.1ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 10:47:47 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 7[0m
+  Rendered shared/_side_bar.html.haml (5.0ms)
+  Rendered groups/index.html.haml within layouts/application (7.7ms)
+  Rendered layouts/_notifications.html.haml (2.1ms)
+Completed 200 OK in 39ms (Views: 33.4ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 10:47:52 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 7[0m
+  Rendered shared/_side_bar.html.haml (4.0ms)
+  Rendered groups/index.html.haml within layouts/application (12.1ms)
+  Rendered layouts/_notifications.html.haml (1.3ms)
+Completed 200 OK in 40ms (Views: 36.7ms | ActiveRecord: 0.5ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 10:47:53 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 7[0m
+  Rendered shared/_side_bar.html.haml (5.6ms)
+  Rendered groups/index.html.haml within layouts/application (8.6ms)
+  Rendered layouts/_notifications.html.haml (1.6ms)
+Completed 200 OK in 35ms (Views: 31.8ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 10:48:39 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (3.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.8ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 7[0m
+  Rendered shared/_side_bar.html.haml (8.5ms)
+  Rendered groups/index.html.haml within layouts/application (14.5ms)
+  Rendered layouts/_notifications.html.haml (10.2ms)
+Completed 200 OK in 75ms (Views: 65.0ms | ActiveRecord: 4.7ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 11:06:32 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (21.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (58.6ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 7[0m
+  Rendered shared/_side_bar.html.haml (65.8ms)
+  Rendered groups/index.html.haml within layouts/application (74.5ms)
+  Rendered layouts/_notifications.html.haml (4.0ms)
+Completed 200 OK in 166ms (Views: 80.6ms | ActiveRecord: 79.7ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 11:07:57 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (4.4ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 7[0m
+  Rendered shared/_side_bar.html.haml (11.2ms)
+  Rendered groups/index.html.haml within layouts/application (20.2ms)
+  Rendered layouts/_notifications.html.haml (3.5ms)
+Completed 200 OK in 78ms (Views: 69.5ms | ActiveRecord: 4.7ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 11:08:00 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (3.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (14.5ms)
+  Rendered groups/new.html.haml within layouts/application (19.3ms)
+  Rendered layouts/_notifications.html.haml (6.9ms)
+Completed 200 OK in 122ms (Views: 103.8ms | ActiveRecord: 3.9ms)
+
+
+Started POST "/groups" for ::1 at 2020-01-16 11:08:10 +0900
+Processing by GroupsController#create as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"jp4XuFdHBCxUtONhUX3Rdfnoz7Z9I9avCS0AEeWHCJXdCPlGuzfkGY6Lw7IWrN2BUBjpB6fLDpb+WQX9Zr8QDQ==", "group"=>{"name"=>"test2"}, "commit"=>"登録する"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[35m (0.4ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mGroup Exists (0.6ms)[0m  [1m[34mSELECT  1 AS one FROM `groups` WHERE `groups`.`name` = BINARY 'test2' LIMIT 1[0m
+  [1m[35mSQL (2.2ms)[0m  [1m[32mINSERT INTO `groups` (`name`, `created_at`, `updated_at`) VALUES ('test2', '2020-01-16 02:08:10', '2020-01-16 02:08:10')[0m
+  [1m[35m (2.7ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 25ms (ActiveRecord: 6.5ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 11:08:10 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (1.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (5.5ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 7[0m
+  Rendered shared/_side_bar.html.haml (22.2ms)
+  Rendered groups/index.html.haml within layouts/application (29.3ms)
+  Rendered layouts/_notifications.html.haml (2.5ms)
+Completed 200 OK in 86ms (Views: 68.9ms | ActiveRecord: 6.9ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 11:08:14 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (4.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (16.2ms)
+  Rendered groups/new.html.haml within layouts/application (23.1ms)
+  Rendered layouts/_notifications.html.haml (2.5ms)
+Completed 200 OK in 78ms (Views: 65.0ms | ActiveRecord: 4.2ms)
+
+
+Started GET "/users?keyword=c" for ::1 at 2020-01-16 11:08:40 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"c"}
+  [1m[36mUser Load (4.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%c%') AND (`users`.`id` != 7) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (2.9ms)
+Completed 200 OK in 35ms (Views: 24.5ms | ActiveRecord: 5.4ms)
+
+
+Started GET "/users?keyword=ch" for ::1 at 2020-01-16 11:08:40 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"ch"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%ch%') AND (`users`.`id` != 7) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (3.7ms)
+Completed 200 OK in 29ms (Views: 21.3ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/users?keyword=c" for ::1 at 2020-01-16 11:08:54 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"c"}
+  [1m[36mUser Load (2.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (3.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%c%') AND (`users`.`id` != 7) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (5.2ms)
+Completed 200 OK in 29ms (Views: 19.8ms | ActiveRecord: 6.1ms)
+
+
+Started GET "/users?keyword=" for ::1 at 2020-01-16 11:08:54 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>""}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  Rendered users/index.json.jbuilder (0.3ms)
+Completed 200 OK in 37ms (Views: 22.6ms | ActiveRecord: 0.2ms)
+
+
+Started GET "/users?keyword=" for ::1 at 2020-01-16 11:08:54 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>""}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  Rendered users/index.json.jbuilder (0.4ms)
+Completed 200 OK in 41ms (Views: 29.7ms | ActiveRecord: 0.2ms)
+
+
+Started GET "/users?keyword=te" for ::1 at 2020-01-16 11:08:55 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"te"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (6.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%te%') AND (`users`.`id` != 7) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (9.5ms)
+Completed 200 OK in 46ms (Views: 33.9ms | ActiveRecord: 6.8ms)
+
+
+Started GET "/users?keyword=te" for ::1 at 2020-01-16 11:08:55 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"te"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%te%') AND (`users`.`id` != 7) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (2.3ms)
+Completed 200 OK in 23ms (Views: 17.3ms | ActiveRecord: 1.4ms)
+
+
+Started GET "/users?keyword=tes" for ::1 at 2020-01-16 11:08:56 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"tes"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (1.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%tes%') AND (`users`.`id` != 7) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (2.3ms)
+Completed 200 OK in 21ms (Views: 15.2ms | ActiveRecord: 1.8ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 11:09:02 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (49.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (38.4ms)
+  Rendered groups/new.html.haml within layouts/application (53.6ms)
+  Rendered layouts/_notifications.html.haml (4.5ms)
+Completed 200 OK in 174ms (Views: 117.7ms | ActiveRecord: 49.5ms)
+
+
+Started GET "/users?keyword=c" for ::1 at 2020-01-16 11:09:07 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"c"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%c%') AND (`users`.`id` != 7) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (2.4ms)
+Completed 200 OK in 22ms (Views: 18.0ms | ActiveRecord: 0.5ms)
+
+
+Started GET "/users?keyword=ch" for ::1 at 2020-01-16 11:09:07 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"ch"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%ch%') AND (`users`.`id` != 7) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (2.2ms)
+Completed 200 OK in 45ms (Views: 38.8ms | ActiveRecord: 0.5ms)
+
+
+Started GET "/users?keyword=cha" for ::1 at 2020-01-16 11:09:07 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"cha"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%cha%') AND (`users`.`id` != 7) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (2.0ms)
+Completed 200 OK in 33ms (Views: 28.2ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/users?keyword=chat" for ::1 at 2020-01-16 11:09:11 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"chat"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (1.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%chat%') AND (`users`.`id` != 7) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (3.3ms)
+Completed 200 OK in 21ms (Views: 16.4ms | ActiveRecord: 1.8ms)
+
+
+Started GET "/users?keyword=chat0" for ::1 at 2020-01-16 11:09:17 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"chat0"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (4.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%chat0%') AND (`users`.`id` != 7) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (7.2ms)
+Completed 200 OK in 22ms (Views: 14.2ms | ActiveRecord: 5.1ms)
+
+
+Started GET "/users?keyword=chat01" for ::1 at 2020-01-16 11:09:17 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"chat01"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (1.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%chat01%') AND (`users`.`id` != 7) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (3.4ms)
+Completed 200 OK in 20ms (Views: 14.7ms | ActiveRecord: 1.7ms)
+
+
+Started GET "/users?keyword=chat012" for ::1 at 2020-01-16 11:09:18 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"chat012"}
+  [1m[36mUser Load (3.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (2.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%chat012%') AND (`users`.`id` != 7) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (3.8ms)
+Completed 200 OK in 40ms (Views: 29.7ms | ActiveRecord: 6.1ms)
+
+
+Started GET "/users?keyword=chat01" for ::1 at 2020-01-16 11:09:19 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"chat01"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (8.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%chat01%') AND (`users`.`id` != 7) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (10.1ms)
+Completed 200 OK in 32ms (Views: 20.6ms | ActiveRecord: 8.6ms)
+
+
+Started GET "/users?keyword=chat0" for ::1 at 2020-01-16 11:09:20 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"chat0"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%chat0%') AND (`users`.`id` != 7) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (7.7ms)
+Completed 200 OK in 31ms (Views: 25.8ms | ActiveRecord: 1.3ms)
+
+
+Started GET "/users?keyword=chat" for ::1 at 2020-01-16 11:09:20 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"chat"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%chat%') AND (`users`.`id` != 7) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (2.7ms)
+Completed 200 OK in 23ms (Views: 18.1ms | ActiveRecord: 1.3ms)
+
+
+Started GET "/users?keyword=cha" for ::1 at 2020-01-16 11:09:20 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"cha"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (1.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%cha%') AND (`users`.`id` != 7) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (3.5ms)
+Completed 200 OK in 17ms (Views: 11.7ms | ActiveRecord: 2.1ms)
+
+
+Started GET "/users/7/edit" for ::1 at 2020-01-16 11:09:30 +0900
+Processing by UsersController#edit as HTML
+  Parameters: {"id"=>"7"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/edit.html.haml within layouts/application
+  Rendered users/edit.html.haml within layouts/application (8.0ms)
+  Rendered layouts/_notifications.html.haml (3.0ms)
+Completed 200 OK in 83ms (Views: 77.7ms | ActiveRecord: 0.3ms)
+
+
+Started DELETE "/users/sign_out" for ::1 at 2020-01-16 11:09:33 +0900
+Processing by Devise::SessionsController#destroy as HTML
+  Parameters: {"authenticity_token"=>"adjtHWlocDJwjw53/KZZ7Qlh/qRY3NHnKtSbpr0esOI6TgPjhRiQB6qwLqS7d1UZoJHYFYI0Cd7doJ5KPiaoeg=="}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 7 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[35m (0.8ms)[0m  [1m[35mBEGIN[0m
+  [1m[35m (12.1ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 21ms (ActiveRecord: 14.1ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 11:09:33 +0900
+Processing by GroupsController#index as HTML
+Completed 401 Unauthorized in 1ms (ActiveRecord: 0.0ms)
+
+
+Started GET "/users/sign_in" for ::1 at 2020-01-16 11:09:33 +0900
+Processing by Devise::SessionsController#new as HTML
+  Rendering devise/sessions/new.html.haml within layouts/application
+  Rendered devise/shared/_links.html.haml (3.6ms)
+  Rendered devise/sessions/new.html.haml within layouts/application (13.6ms)
+  Rendered layouts/_notifications.html.haml (9.7ms)
+Completed 200 OK in 71ms (Views: 70.5ms | ActiveRecord: 0.0ms)
+
+
+Started GET "/users/sign_up" for ::1 at 2020-01-16 11:09:35 +0900
+Processing by Devise::RegistrationsController#new as HTML
+  Rendering devise/registrations/new.html.haml within layouts/application
+  Rendered devise/shared/_links.html.haml (3.7ms)
+DEPRECATION WARNING: [Devise] `DeviseHelper.devise_error_messages!`
+is deprecated and it will be removed in the next major version.
+To customize the errors styles please run `rails g devise:views` and modify the
+`devise/shared/error_messages` partial.
+ (called from block in _app_views_devise_registrations_new_html_haml___68481421368606785_70332921885800 at /Users/choisdavid/projects/chat-space/app/views/devise/registrations/new.html.haml:9)
+  Rendered devise/registrations/new.html.haml within layouts/application (108.1ms)
+  Rendered layouts/_notifications.html.haml (2.9ms)
+Completed 200 OK in 228ms (Views: 226.7ms | ActiveRecord: 0.0ms)
+
+
+Started POST "/users" for ::1 at 2020-01-16 11:09:49 +0900
+Processing by Devise::RegistrationsController#create as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"rZjOrNGbuzgJptlz9YagCb7SNkT6E1hkepmyjJiwhS5WBxZA2219Hz/YAhKawhyH58Fuq1ZHuGpPkZXA77mkWA==", "user"=>{"name"=>"test", "email"=>"chacha@gmail.comfggggggggg", "password"=>"[FILTERED]", "password_confirmation"=>"[FILTERED]"}, "commit"=>"Create Account"}
+  [1m[35m (0.3ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Exists (0.5ms)[0m  [1m[34mSELECT  1 AS one FROM `users` WHERE `users`.`email` = BINARY 'chacha@gmail.comfggggggggg' LIMIT 1[0m
+  [1m[35mSQL (0.3ms)[0m  [1m[32mINSERT INTO `users` (`name`, `email`, `encrypted_password`, `created_at`, `updated_at`) VALUES ('test', 'chacha@gmail.comfggggggggg', '$2a$11$AsumEYoUQtoT4XRV5BqZveKOpVa3JaWYchH/62bsFx7Uk.ZpkwSbS', '2020-01-16 02:09:49', '2020-01-16 02:09:49')[0m
+  [1m[35m (2.3ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 199ms (ActiveRecord: 3.4ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 11:09:49 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  Rendered shared/_side_bar.html.haml (5.6ms)
+  Rendered groups/index.html.haml within layouts/application (8.6ms)
+  Rendered layouts/_notifications.html.haml (1.8ms)
+Completed 200 OK in 95ms (Views: 84.9ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 11:09:53 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (5.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (16.2ms)
+  Rendered groups/new.html.haml within layouts/application (19.3ms)
+  Rendered layouts/_notifications.html.haml (7.5ms)
+Completed 200 OK in 131ms (Views: 120.2ms | ActiveRecord: 5.3ms)
+
+
+Started GET "/users?keyword=te" for ::1 at 2020-01-16 11:09:56 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"te"}
+  [1m[36mUser Load (3.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (17.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%te%') AND (`users`.`id` != 8) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (20.3ms)
+Completed 200 OK in 58ms (Views: 31.0ms | ActiveRecord: 20.5ms)
+
+
+Started GET "/users?keyword=te" for ::1 at 2020-01-16 11:09:56 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"te"}
+  [1m[36mUser Load (4.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (65.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%te%') AND (`users`.`id` != 8) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (66.5ms)
+Completed 200 OK in 94ms (Views: 18.4ms | ActiveRecord: 69.7ms)
+
+
+Started GET "/users?keyword=tes" for ::1 at 2020-01-16 11:09:56 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"tes"}
+  [1m[36mUser Load (1.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%tes%') AND (`users`.`id` != 8) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (1.5ms)
+Completed 200 OK in 50ms (Views: 39.5ms | ActiveRecord: 1.7ms)
+
+
+Started GET "/users?keyword=test" for ::1 at 2020-01-16 11:09:57 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"test"}
+  [1m[36mUser Load (12.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (42.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%test%') AND (`users`.`id` != 8) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (47.1ms)
+Completed 200 OK in 117ms (Views: 36.5ms | ActiveRecord: 54.9ms)
+
+
+Started GET "/users?keyword=tes" for ::1 at 2020-01-16 11:09:58 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"tes"}
+  [1m[36mUser Load (2.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (19.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%tes%') AND (`users`.`id` != 8) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (20.5ms)
+Completed 200 OK in 44ms (Views: 16.5ms | ActiveRecord: 21.8ms)
+
+
+Started GET "/users?keyword=te" for ::1 at 2020-01-16 11:09:58 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"te"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (1.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%te%') AND (`users`.`id` != 8) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (5.4ms)
+Completed 200 OK in 34ms (Views: 26.0ms | ActiveRecord: 2.4ms)
+
+
+Started GET "/users?keyword=t" for ::1 at 2020-01-16 11:09:58 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"t"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%t%') AND (`users`.`id` != 8) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (2.6ms)
+Completed 200 OK in 42ms (Views: 35.6ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/users?keyword=" for ::1 at 2020-01-16 11:09:58 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>""}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  Rendered users/index.json.jbuilder (0.5ms)
+Completed 200 OK in 51ms (Views: 30.0ms | ActiveRecord: 0.5ms)
+
+
+Started GET "/users?keyword=" for ::1 at 2020-01-16 11:09:59 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>""}
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  Rendered users/index.json.jbuilder (0.7ms)
+Completed 200 OK in 58ms (Views: 31.7ms | ActiveRecord: 1.3ms)
+
+
+Started GET "/users?keyword=" for ::1 at 2020-01-16 11:09:59 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>""}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  Rendered users/index.json.jbuilder (2.3ms)
+Completed 200 OK in 66ms (Views: 50.4ms | ActiveRecord: 0.2ms)
+
+
+Started GET "/users?keyword=c" for ::1 at 2020-01-16 11:10:02 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"c"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%c%') AND (`users`.`id` != 8) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (2.7ms)
+Completed 200 OK in 21ms (Views: 14.5ms | ActiveRecord: 1.2ms)
+
+
+Started GET "/users?keyword=ch" for ::1 at 2020-01-16 11:10:03 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"ch"}
+  [1m[36mUser Load (9.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (4.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%ch%') AND (`users`.`id` != 8) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (6.6ms)
+Completed 200 OK in 33ms (Views: 14.2ms | ActiveRecord: 13.9ms)
+
+
+Started GET "/users?keyword=cha" for ::1 at 2020-01-16 11:10:03 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"cha"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%cha%') AND (`users`.`id` != 8) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (1.5ms)
+Completed 200 OK in 17ms (Views: 13.1ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 11:10:33 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (19.2ms)
+  Rendered groups/new.html.haml within layouts/application (24.0ms)
+  Rendered layouts/_notifications.html.haml (3.5ms)
+Completed 200 OK in 105ms (Views: 97.2ms | ActiveRecord: 0.3ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 11:25:02 +0900
+  [1m[36mActiveRecord::SchemaMigration Load (0.2ms)[0m  [1m[34mSELECT `schema_migrations`.* FROM `schema_migrations`[0m
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  Rendered shared/_side_bar.html.haml (64.5ms)
+  Rendered groups/index.html.haml within layouts/application (80.2ms)
+  Rendered layouts/_notifications.html.haml (1.8ms)
+Completed 200 OK in 418ms (Views: 370.0ms | ActiveRecord: 18.1ms)
+
+
+Started GET "/groups/new" for ::1 at 2020-01-16 11:25:08 +0900
+Processing by GroupsController#new as HTML
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/new.html.haml within layouts/application
+  Rendered groups/_form.html.haml (1072.9ms)
+  Rendered groups/new.html.haml within layouts/application (1076.5ms)
+  Rendered layouts/_notifications.html.haml (2.4ms)
+Completed 200 OK in 1127ms (Views: 1105.2ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/users?keyword=chat0116" for ::1 at 2020-01-16 11:25:19 +0900
+Processing by UsersController#index as JSON
+  Parameters: {"keyword"=>"chat0116"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering users/index.json.jbuilder
+  [1m[36mUser Load (7.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE (name LIKE '%chat0116%') AND (`users`.`id` != 8) LIMIT 10[0m
+  Rendered users/index.json.jbuilder (9.5ms)
+Completed 200 OK in 33ms (Views: 19.2ms | ActiveRecord: 8.1ms)
+
+
+Started POST "/groups" for ::1 at 2020-01-16 11:25:23 +0900
+Processing by GroupsController#create as HTML
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"NeXXFq5v8w57suemZQNxY1cuajV1EayFfJa+erOVYeHOeg/6pJk1KU3MPMcKR83tDj0y2tlFTItJnpk2xJxAlw==", "group"=>{"name"=>"chatchat", "user_ids"=>["8", "4"]}, "commit"=>"登録する"}
+  [1m[36mUser Load (1.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mUser Load (1.9ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` IN (8, 4)[0m
+  [1m[35m (18.7ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mGroup Exists (0.4ms)[0m  [1m[34mSELECT  1 AS one FROM `groups` WHERE `groups`.`name` = BINARY 'chatchat' LIMIT 1[0m
+  [1m[35mSQL (0.2ms)[0m  [1m[32mINSERT INTO `groups` (`name`, `created_at`, `updated_at`) VALUES ('chatchat', '2020-01-16 02:25:23', '2020-01-16 02:25:23')[0m
+  [1m[35mSQL (0.6ms)[0m  [1m[32mINSERT INTO `group_users` (`group_id`, `user_id`, `created_at`, `updated_at`) VALUES (17, 8, '2020-01-16 02:25:23', '2020-01-16 02:25:23')[0m
+  [1m[35mSQL (0.1ms)[0m  [1m[32mINSERT INTO `group_users` (`group_id`, `user_id`, `created_at`, `updated_at`) VALUES (17, 4, '2020-01-16 02:25:23', '2020-01-16 02:25:23')[0m
+  [1m[35m (0.5ms)[0m  [1m[35mCOMMIT[0m
+Redirected to http://localhost:3000/
+Completed 302 Found in 43ms (ActiveRecord: 23.9ms)
+
+
+Started GET "/" for ::1 at 2020-01-16 11:25:23 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.9ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (38.2ms)
+  Rendered groups/index.html.haml within layouts/application (42.6ms)
+  Rendered layouts/_notifications.html.haml (1.7ms)
+Completed 200 OK in 90ms (Views: 75.9ms | ActiveRecord: 11.8ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 11:25:26 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (2.7ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (9.9ms)
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  Rendered collection of templates [0 times] (0.0ms)
+  Rendered messages/_main_chat.html.haml (8.1ms)
+  Rendered messages/index.html.haml within layouts/application (30.4ms)
+  Rendered layouts/_notifications.html.haml (1.3ms)
+Completed 200 OK in 74ms (Views: 54.5ms | ActiveRecord: 5.8ms)
+
+
+Started POST "/groups/17/messages" for ::1 at 2020-01-16 11:25:35 +0900
+Processing by MessagesController#create as JSON
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"I3tcsHoxfP8eC2juQZoN4pGg1P9foQOEcMoHxCUaezvY5IRccMe62Ch1s48u3rFsyLOMEPP144pFwiCIUhNaTQ==", "message"=>{"content"=>"よかった"}, "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  [1m[35m (0.3ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (3.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 LIMIT 1[0m
+  [1m[35mSQL (0.5ms)[0m  [1m[32mINSERT INTO `messages` (`content`, `group_id`, `user_id`, `created_at`, `updated_at`) VALUES ('よかった', 17, 8, '2020-01-16 02:25:35', '2020-01-16 02:25:35')[0m
+  [1m[35m (0.3ms)[0m  [1m[35mCOMMIT[0m
+  Rendering messages/create.json.jbuilder
+  Rendered messages/create.json.jbuilder (0.6ms)
+Completed 200 OK in 30ms (Views: 12.3ms | ActiveRecord: 5.0ms)
+
+
+Started GET "/groups/17/[object" for ::1 at 2020-01-16 11:25:35 +0900
+  
+ActionController::RoutingError (No route matches [GET] "/groups/17/[object"):
+  
+actionpack (5.0.7.2) lib/action_dispatch/middleware/debug_exceptions.rb:53:in `call'
+web-console (3.7.0) lib/web_console/middleware.rb:135:in `call_app'
+web-console (3.7.0) lib/web_console/middleware.rb:30:in `block in call'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `catch'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
+railties (5.0.7.2) lib/rails/rack/logger.rb:36:in `call_app'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `block in call'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `block in tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:26:in `tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `tagged'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `call'
+sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:13:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/request_id.rb:24:in `call'
+rack (2.0.7) lib/rack/method_override.rb:22:in `call'
+rack (2.0.7) lib/rack/runtime.rb:22:in `call'
+activesupport (5.0.7.2) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/executor.rb:12:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/static.rb:136:in `call'
+rack (2.0.7) lib/rack/sendfile.rb:111:in `call'
+railties (5.0.7.2) lib/rails/engine.rb:522:in `call'
+puma (3.12.1) lib/puma/configuration.rb:227:in `call'
+puma (3.12.1) lib/puma/server.rb:660:in `handle_request'
+puma (3.12.1) lib/puma/server.rb:474:in `process_client'
+puma (3.12.1) lib/puma/server.rb:334:in `block in run'
+puma (3.12.1) lib/puma/thread_pool.rb:135:in `block in spawn_thread'
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (1.1ms)
+  Rendered collection of /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/routes/_route.html.erb [27 times] (16.4ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/routes/_table.html.erb (2.2ms)
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (1.3ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (128.0ms)
+Started POST "/groups/17/messages" for ::1 at 2020-01-16 11:25:54 +0900
+Processing by MessagesController#create as JSON
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"I3tcsHoxfP8eC2juQZoN4pGg1P9foQOEcMoHxCUaezvY5IRccMe62Ch1s48u3rFsyLOMEPP144pFwiCIUhNaTQ==", "message"=>{"content"=>"死ぬかと思った"}, "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 LIMIT 1[0m
+  [1m[35mSQL (0.2ms)[0m  [1m[32mINSERT INTO `messages` (`content`, `group_id`, `user_id`, `created_at`, `updated_at`) VALUES ('死ぬかと思った', 17, 8, '2020-01-16 02:25:54', '2020-01-16 02:25:54')[0m
+  [1m[35m (7.6ms)[0m  [1m[35mCOMMIT[0m
+  Rendering messages/create.json.jbuilder
+  Rendered messages/create.json.jbuilder (0.8ms)
+Completed 200 OK in 36ms (Views: 20.8ms | ActiveRecord: 8.4ms)
+
+
+Started GET "/groups/17/[object" for ::1 at 2020-01-16 11:25:54 +0900
+  
+ActionController::RoutingError (No route matches [GET] "/groups/17/[object"):
+  
+actionpack (5.0.7.2) lib/action_dispatch/middleware/debug_exceptions.rb:53:in `call'
+web-console (3.7.0) lib/web_console/middleware.rb:135:in `call_app'
+web-console (3.7.0) lib/web_console/middleware.rb:30:in `block in call'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `catch'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
+railties (5.0.7.2) lib/rails/rack/logger.rb:36:in `call_app'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `block in call'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `block in tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:26:in `tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `tagged'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `call'
+sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:13:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/request_id.rb:24:in `call'
+rack (2.0.7) lib/rack/method_override.rb:22:in `call'
+rack (2.0.7) lib/rack/runtime.rb:22:in `call'
+activesupport (5.0.7.2) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/executor.rb:12:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/static.rb:136:in `call'
+rack (2.0.7) lib/rack/sendfile.rb:111:in `call'
+railties (5.0.7.2) lib/rails/engine.rb:522:in `call'
+puma (3.12.1) lib/puma/configuration.rb:227:in `call'
+puma (3.12.1) lib/puma/server.rb:660:in `handle_request'
+puma (3.12.1) lib/puma/server.rb:474:in `process_client'
+puma (3.12.1) lib/puma/server.rb:334:in `block in run'
+puma (3.12.1) lib/puma/thread_pool.rb:135:in `block in spawn_thread'
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (0.9ms)
+  Rendered collection of /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/routes/_route.html.erb [27 times] (6.6ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/routes/_table.html.erb (0.9ms)
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (1.1ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (102.9ms)
+Started GET "/" for ::1 at 2020-01-16 14:22:54 +0900
+  [1m[36mActiveRecord::SchemaMigration Load (0.4ms)[0m  [1m[34mSELECT `schema_migrations`.* FROM `schema_migrations`[0m
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (91.4ms)
+  Rendered groups/index.html.haml within layouts/application (103.7ms)
+  Rendered layouts/_notifications.html.haml (2.2ms)
+Completed 200 OK in 436ms (Views: 395.9ms | ActiveRecord: 16.9ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 14:22:58 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (8.0ms)
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [2 times] (3.2ms)
+  Rendered messages/_main_chat.html.haml (14.9ms)
+  Rendered messages/index.html.haml within layouts/application (32.4ms)
+Completed 500 Internal Server Error in 46ms (ActiveRecord: 1.6ms)
+
+
+  
+ActionView::Template::Error (Indenting at the beginning of the document is illegal.):
+    1:   .message {data: {message: {id: message.id}}}
+    2:   .upper-message
+    3:     .upper-message__user-name
+    4:       = message.user.name
+  
+app/views/messages/_message.html.haml:1
+app/views/messages/_main_chat.html.haml:2:in `_app_views_messages__main_chat_html_haml__1553754265525883699_70184621109780'
+app/views/messages/index.html.haml:21:in `_app_views_messages_index_html_haml___3660036635029112305_70184621345920'
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_source.html.erb (5.9ms)
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (2.2ms)
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (0.9ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout (85.1ms)
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 14:23:03 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (7.3ms)
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [2 times] (1.1ms)
+  Rendered messages/_main_chat.html.haml (5.7ms)
+  Rendered messages/index.html.haml within layouts/application (20.3ms)
+Completed 500 Internal Server Error in 32ms (ActiveRecord: 1.9ms)
+
+
+  
+ActionView::Template::Error (Indenting at the beginning of the document is illegal.):
+    1:   .message {data: {message: {id: message.id}}}
+    2:   .upper-message
+    3:     .upper-message__user-name
+    4:       = message.user.name
+  
+app/views/messages/_message.html.haml:1
+app/views/messages/_main_chat.html.haml:2:in `_app_views_messages__main_chat_html_haml__1553754265525883699_70184670878140'
+app/views/messages/index.html.haml:21:in `_app_views_messages_index_html_haml___3660036635029112305_70184671234580'
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_source.html.erb (4.2ms)
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (1.6ms)
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (0.8ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout (74.5ms)
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 14:29:24 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (7.7ms)
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [2 times] (1.4ms)
+  Rendered messages/_main_chat.html.haml (8.5ms)
+  Rendered messages/index.html.haml within layouts/application (24.2ms)
+Completed 500 Internal Server Error in 32ms (ActiveRecord: 1.5ms)
+
+
+  
+ActionView::Template::Error (Illegal nesting: content can't be both given on the same line as %div and nested within it.):
+    1: .message {data: {message: {id: message.id}}}
+    2:   .upper-message
+    3:     .upper-message__user-name
+    4:       = message.user.name
+    5:     .upper-message__date
+  
+app/views/messages/_message.html.haml:2
+app/views/messages/_main_chat.html.haml:2:in `_app_views_messages__main_chat_html_haml__1553754265525883699_70184632663420'
+app/views/messages/index.html.haml:21:in `_app_views_messages_index_html_haml___3660036635029112305_70184670825540'
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_source.html.erb (4.2ms)
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (1.7ms)
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (0.8ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout (75.3ms)
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 15:08:45 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (2.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (7.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (9.8ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (31.1ms)
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (5.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (8.6ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [2 times] (14.0ms)
+  Rendered messages/_main_chat.html.haml (95.2ms)
+  Rendered messages/index.html.haml within layouts/application (150.0ms)
+  Rendered layouts/_notifications.html.haml (2.6ms)
+Completed 200 OK in 274ms (Views: 206.0ms | ActiveRecord: 34.7ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 15:10:32 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (8.4ms)
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [2 times] (13.4ms)
+  Rendered messages/_main_chat.html.haml (19.6ms)
+  Rendered messages/index.html.haml within layouts/application (43.5ms)
+  Rendered layouts/_notifications.html.haml (2.4ms)
+Completed 200 OK in 101ms (Views: 90.9ms | ActiveRecord: 2.4ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 15:11:43 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.8ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (1.2ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (113.4ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (128.0ms)
+  [1m[36mUser Load (10.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (2.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [2 times] (6.2ms)
+  Rendered messages/_main_chat.html.haml (26.0ms)
+  Rendered messages/index.html.haml within layouts/application (177.4ms)
+  Rendered layouts/_notifications.html.haml (10.1ms)
+Completed 200 OK in 280ms (Views: 140.7ms | ActiveRecord: 130.7ms)
+
+
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 15:13:16 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (12.0ms)
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.9ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (1.4ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [2 times] (4.2ms)
+  Rendered messages/_main_chat.html.haml (14.8ms)
+  Rendered messages/index.html.haml within layouts/application (42.4ms)
+  Rendered layouts/_notifications.html.haml (5.1ms)
+Completed 200 OK in 111ms (Views: 101.6ms | ActiveRecord: 4.8ms)
+
+
+Started POST "/groups/17/messages" for ::1 at 2020-01-16 15:16:49 +0900
+Processing by MessagesController#create as JSON
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"xp64DYeymGSnVmcTDj0iufoWl4mGaMxY9QXXE1H0n449AWDhjUReQ5EovHJheZ43owXPZio8LFbADfBfJv2++A==", "message"=>{"content"=>"解決した、スペースが残っていたのか！"}, "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 LIMIT 1[0m
+  [1m[35mSQL (0.2ms)[0m  [1m[32mINSERT INTO `messages` (`content`, `group_id`, `user_id`, `created_at`, `updated_at`) VALUES ('解決した、スペースが残っていたのか！', 17, 8, '2020-01-16 06:16:49', '2020-01-16 06:16:49')[0m
+  [1m[35m (0.8ms)[0m  [1m[35mCOMMIT[0m
+  Rendering messages/create.json.jbuilder
+  Rendered messages/create.json.jbuilder (1.2ms)
+Completed 200 OK in 23ms (Views: 10.3ms | ActiveRecord: 2.1ms)
+
+
+Started GET "/groups/17/[object" for ::1 at 2020-01-16 15:16:49 +0900
+  
+ActionController::RoutingError (No route matches [GET] "/groups/17/[object"):
+  
+actionpack (5.0.7.2) lib/action_dispatch/middleware/debug_exceptions.rb:53:in `call'
+web-console (3.7.0) lib/web_console/middleware.rb:135:in `call_app'
+web-console (3.7.0) lib/web_console/middleware.rb:30:in `block in call'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `catch'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
+railties (5.0.7.2) lib/rails/rack/logger.rb:36:in `call_app'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `block in call'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `block in tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:26:in `tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `tagged'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `call'
+sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:13:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/request_id.rb:24:in `call'
+rack (2.0.7) lib/rack/method_override.rb:22:in `call'
+rack (2.0.7) lib/rack/runtime.rb:22:in `call'
+activesupport (5.0.7.2) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/executor.rb:12:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/static.rb:136:in `call'
+rack (2.0.7) lib/rack/sendfile.rb:111:in `call'
+railties (5.0.7.2) lib/rails/engine.rb:522:in `call'
+puma (3.12.1) lib/puma/configuration.rb:227:in `call'
+puma (3.12.1) lib/puma/server.rb:660:in `handle_request'
+puma (3.12.1) lib/puma/server.rb:474:in `process_client'
+puma (3.12.1) lib/puma/server.rb:334:in `block in run'
+puma (3.12.1) lib/puma/thread_pool.rb:135:in `block in spawn_thread'
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (1.1ms)
+  Rendered collection of /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/routes/_route.html.erb [27 times] (17.2ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/routes/_table.html.erb (3.9ms)
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (1.3ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb within rescues/layout (121.6ms)
+Started GET "/" for ::1 at 2020-01-16 16:51:11 +0900
+  [1m[36mActiveRecord::SchemaMigration Load (0.3ms)[0m  [1m[34mSELECT `schema_migrations`.* FROM `schema_migrations`[0m
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (94.7ms)
+  Rendered groups/index.html.haml within layouts/application (113.8ms)
+  Rendered layouts/_notifications.html.haml (1.5ms)
+Completed 200 OK in 588ms (Views: 545.5ms | ActiveRecord: 17.8ms)
+
+
+Started GET "/api/messages" for ::1 at 2020-01-16 16:51:19 +0900
+  
+ActionController::RoutingError (No route matches [GET] "/api/messages"):
+  
+actionpack (5.0.7.2) lib/action_dispatch/middleware/debug_exceptions.rb:53:in `call'
+web-console (3.7.0) lib/web_console/middleware.rb:135:in `call_app'
+web-console (3.7.0) lib/web_console/middleware.rb:30:in `block in call'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `catch'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
+railties (5.0.7.2) lib/rails/rack/logger.rb:36:in `call_app'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `block in call'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `block in tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:26:in `tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `tagged'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `call'
+sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:13:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/request_id.rb:24:in `call'
+rack (2.0.7) lib/rack/method_override.rb:22:in `call'
+rack (2.0.7) lib/rack/runtime.rb:22:in `call'
+activesupport (5.0.7.2) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/executor.rb:12:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/static.rb:136:in `call'
+rack (2.0.7) lib/rack/sendfile.rb:111:in `call'
+railties (5.0.7.2) lib/rails/engine.rb:522:in `call'
+puma (3.12.1) lib/puma/configuration.rb:227:in `call'
+puma (3.12.1) lib/puma/server.rb:660:in `handle_request'
+puma (3.12.1) lib/puma/server.rb:474:in `process_client'
+puma (3.12.1) lib/puma/server.rb:334:in `block in run'
+puma (3.12.1) lib/puma/thread_pool.rb:135:in `block in spawn_thread'
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.text.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.text.erb (0.7ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb (27.6ms)
+Started GET "/api/messages" for ::1 at 2020-01-16 16:51:26 +0900
+  
+ActionController::RoutingError (No route matches [GET] "/api/messages"):
+  
+actionpack (5.0.7.2) lib/action_dispatch/middleware/debug_exceptions.rb:53:in `call'
+web-console (3.7.0) lib/web_console/middleware.rb:135:in `call_app'
+web-console (3.7.0) lib/web_console/middleware.rb:30:in `block in call'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `catch'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
+railties (5.0.7.2) lib/rails/rack/logger.rb:36:in `call_app'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `block in call'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `block in tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:26:in `tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `tagged'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `call'
+sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:13:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/request_id.rb:24:in `call'
+rack (2.0.7) lib/rack/method_override.rb:22:in `call'
+rack (2.0.7) lib/rack/runtime.rb:22:in `call'
+activesupport (5.0.7.2) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/executor.rb:12:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/static.rb:136:in `call'
+rack (2.0.7) lib/rack/sendfile.rb:111:in `call'
+railties (5.0.7.2) lib/rails/engine.rb:522:in `call'
+puma (3.12.1) lib/puma/configuration.rb:227:in `call'
+puma (3.12.1) lib/puma/server.rb:660:in `handle_request'
+puma (3.12.1) lib/puma/server.rb:474:in `process_client'
+puma (3.12.1) lib/puma/server.rb:334:in `block in run'
+puma (3.12.1) lib/puma/thread_pool.rb:135:in `block in spawn_thread'
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.text.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.text.erb (0.6ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb (24.5ms)
+Started GET "/api/messages" for ::1 at 2020-01-16 16:51:33 +0900
+  
+ActionController::RoutingError (No route matches [GET] "/api/messages"):
+  
+actionpack (5.0.7.2) lib/action_dispatch/middleware/debug_exceptions.rb:53:in `call'
+web-console (3.7.0) lib/web_console/middleware.rb:135:in `call_app'
+web-console (3.7.0) lib/web_console/middleware.rb:30:in `block in call'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `catch'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
+railties (5.0.7.2) lib/rails/rack/logger.rb:36:in `call_app'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `block in call'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `block in tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:26:in `tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `tagged'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `call'
+sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:13:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/request_id.rb:24:in `call'
+rack (2.0.7) lib/rack/method_override.rb:22:in `call'
+rack (2.0.7) lib/rack/runtime.rb:22:in `call'
+activesupport (5.0.7.2) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/executor.rb:12:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/static.rb:136:in `call'
+rack (2.0.7) lib/rack/sendfile.rb:111:in `call'
+railties (5.0.7.2) lib/rails/engine.rb:522:in `call'
+puma (3.12.1) lib/puma/configuration.rb:227:in `call'
+puma (3.12.1) lib/puma/server.rb:660:in `handle_request'
+puma (3.12.1) lib/puma/server.rb:474:in `process_client'
+puma (3.12.1) lib/puma/server.rb:334:in `block in run'
+puma (3.12.1) lib/puma/thread_pool.rb:135:in `block in spawn_thread'
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.text.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.text.erb (0.7ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb (31.5ms)
+Started GET "/" for ::1 at 2020-01-16 16:51:37 +0900
+Processing by GroupsController#index as HTML
+  [1m[36mUser Load (1.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  Rendering groups/index.html.haml within layouts/application
+  [1m[36mGroup Load (4.0ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (2.1ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (19.4ms)
+  Rendered groups/index.html.haml within layouts/application (22.7ms)
+  Rendered layouts/_notifications.html.haml (1.9ms)
+Completed 200 OK in 91ms (Views: 77.9ms | ActiveRecord: 7.3ms)
+
+
+Started GET "/api/messages" for ::1 at 2020-01-16 16:51:40 +0900
+  
+ActionController::RoutingError (No route matches [GET] "/api/messages"):
+  
+actionpack (5.0.7.2) lib/action_dispatch/middleware/debug_exceptions.rb:53:in `call'
+web-console (3.7.0) lib/web_console/middleware.rb:135:in `call_app'
+web-console (3.7.0) lib/web_console/middleware.rb:30:in `block in call'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `catch'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
+railties (5.0.7.2) lib/rails/rack/logger.rb:36:in `call_app'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `block in call'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `block in tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:26:in `tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `tagged'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `call'
+sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:13:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/request_id.rb:24:in `call'
+rack (2.0.7) lib/rack/method_override.rb:22:in `call'
+rack (2.0.7) lib/rack/runtime.rb:22:in `call'
+activesupport (5.0.7.2) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/executor.rb:12:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/static.rb:136:in `call'
+rack (2.0.7) lib/rack/sendfile.rb:111:in `call'
+railties (5.0.7.2) lib/rails/engine.rb:522:in `call'
+puma (3.12.1) lib/puma/configuration.rb:227:in `call'
+puma (3.12.1) lib/puma/server.rb:660:in `handle_request'
+puma (3.12.1) lib/puma/server.rb:474:in `process_client'
+puma (3.12.1) lib/puma/server.rb:334:in `block in run'
+puma (3.12.1) lib/puma/thread_pool.rb:135:in `block in spawn_thread'
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.text.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.text.erb (0.9ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb (23.3ms)
+Started GET "/api/messages" for ::1 at 2020-01-16 16:51:45 +0900
+  
+ActionController::RoutingError (No route matches [GET] "/api/messages"):
+  
+actionpack (5.0.7.2) lib/action_dispatch/middleware/debug_exceptions.rb:53:in `call'
+web-console (3.7.0) lib/web_console/middleware.rb:135:in `call_app'
+web-console (3.7.0) lib/web_console/middleware.rb:30:in `block in call'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `catch'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
+railties (5.0.7.2) lib/rails/rack/logger.rb:36:in `call_app'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `block in call'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `block in tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:26:in `tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `tagged'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `call'
+sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:13:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/request_id.rb:24:in `call'
+rack (2.0.7) lib/rack/method_override.rb:22:in `call'
+rack (2.0.7) lib/rack/runtime.rb:22:in `call'
+activesupport (5.0.7.2) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/executor.rb:12:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/static.rb:136:in `call'
+rack (2.0.7) lib/rack/sendfile.rb:111:in `call'
+railties (5.0.7.2) lib/rails/engine.rb:522:in `call'
+puma (3.12.1) lib/puma/configuration.rb:227:in `call'
+puma (3.12.1) lib/puma/server.rb:660:in `handle_request'
+puma (3.12.1) lib/puma/server.rb:474:in `process_client'
+puma (3.12.1) lib/puma/server.rb:334:in `block in run'
+puma (3.12.1) lib/puma/thread_pool.rb:135:in `block in spawn_thread'
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.text.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.text.erb (0.6ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb (40.8ms)
+Started GET "/api/messages" for ::1 at 2020-01-16 16:51:47 +0900
+  
+ActionController::RoutingError (No route matches [GET] "/api/messages"):
+  
+actionpack (5.0.7.2) lib/action_dispatch/middleware/debug_exceptions.rb:53:in `call'
+web-console (3.7.0) lib/web_console/middleware.rb:135:in `call_app'
+web-console (3.7.0) lib/web_console/middleware.rb:30:in `block in call'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `catch'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
+railties (5.0.7.2) lib/rails/rack/logger.rb:36:in `call_app'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `block in call'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `block in tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:26:in `tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `tagged'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `call'
+sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:13:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/request_id.rb:24:in `call'
+rack (2.0.7) lib/rack/method_override.rb:22:in `call'
+rack (2.0.7) lib/rack/runtime.rb:22:in `call'
+activesupport (5.0.7.2) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/executor.rb:12:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/static.rb:136:in `call'
+rack (2.0.7) lib/rack/sendfile.rb:111:in `call'
+railties (5.0.7.2) lib/rails/engine.rb:522:in `call'
+puma (3.12.1) lib/puma/configuration.rb:227:in `call'
+puma (3.12.1) lib/puma/server.rb:660:in `handle_request'
+puma (3.12.1) lib/puma/server.rb:474:in `process_client'
+puma (3.12.1) lib/puma/server.rb:334:in `block in run'
+puma (3.12.1) lib/puma/thread_pool.rb:135:in `block in spawn_thread'
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.text.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.text.erb (0.7ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb (25.7ms)
+Started GET "/api/messages" for ::1 at 2020-01-16 16:51:52 +0900
+  
+ActionController::RoutingError (No route matches [GET] "/api/messages"):
+  
+actionpack (5.0.7.2) lib/action_dispatch/middleware/debug_exceptions.rb:53:in `call'
+web-console (3.7.0) lib/web_console/middleware.rb:135:in `call_app'
+web-console (3.7.0) lib/web_console/middleware.rb:30:in `block in call'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `catch'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
+railties (5.0.7.2) lib/rails/rack/logger.rb:36:in `call_app'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `block in call'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `block in tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:26:in `tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `tagged'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `call'
+sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:13:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/request_id.rb:24:in `call'
+rack (2.0.7) lib/rack/method_override.rb:22:in `call'
+rack (2.0.7) lib/rack/runtime.rb:22:in `call'
+activesupport (5.0.7.2) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/executor.rb:12:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/static.rb:136:in `call'
+rack (2.0.7) lib/rack/sendfile.rb:111:in `call'
+railties (5.0.7.2) lib/rails/engine.rb:522:in `call'
+puma (3.12.1) lib/puma/configuration.rb:227:in `call'
+puma (3.12.1) lib/puma/server.rb:660:in `handle_request'
+puma (3.12.1) lib/puma/server.rb:474:in `process_client'
+puma (3.12.1) lib/puma/server.rb:334:in `block in run'
+puma (3.12.1) lib/puma/thread_pool.rb:135:in `block in spawn_thread'
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.text.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.text.erb (0.4ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb (24.8ms)
+Started GET "/api/messages" for ::1 at 2020-01-16 16:51:54 +0900
+  
+ActionController::RoutingError (No route matches [GET] "/api/messages"):
+  
+actionpack (5.0.7.2) lib/action_dispatch/middleware/debug_exceptions.rb:53:in `call'
+web-console (3.7.0) lib/web_console/middleware.rb:135:in `call_app'
+web-console (3.7.0) lib/web_console/middleware.rb:30:in `block in call'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `catch'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
+railties (5.0.7.2) lib/rails/rack/logger.rb:36:in `call_app'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `block in call'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `block in tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:26:in `tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `tagged'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `call'
+sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:13:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/request_id.rb:24:in `call'
+rack (2.0.7) lib/rack/method_override.rb:22:in `call'
+rack (2.0.7) lib/rack/runtime.rb:22:in `call'
+activesupport (5.0.7.2) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/executor.rb:12:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/static.rb:136:in `call'
+rack (2.0.7) lib/rack/sendfile.rb:111:in `call'
+railties (5.0.7.2) lib/rails/engine.rb:522:in `call'
+puma (3.12.1) lib/puma/configuration.rb:227:in `call'
+puma (3.12.1) lib/puma/server.rb:660:in `handle_request'
+puma (3.12.1) lib/puma/server.rb:474:in `process_client'
+puma (3.12.1) lib/puma/server.rb:334:in `block in run'
+puma (3.12.1) lib/puma/thread_pool.rb:135:in `block in spawn_thread'
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.text.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.text.erb (0.6ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb (35.7ms)
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 16:51:55 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (7.9ms)
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [3 times] (4.7ms)
+  Rendered messages/_main_chat.html.haml (26.6ms)
+  Rendered messages/index.html.haml within layouts/application (48.6ms)
+  Rendered layouts/_notifications.html.haml (1.4ms)
+Completed 200 OK in 81ms (Views: 74.0ms | ActiveRecord: 1.9ms)
+
+
+Started GET "/api/messages" for ::1 at 2020-01-16 16:51:59 +0900
+  
+ActionController::RoutingError (No route matches [GET] "/api/messages"):
+  
+actionpack (5.0.7.2) lib/action_dispatch/middleware/debug_exceptions.rb:53:in `call'
+web-console (3.7.0) lib/web_console/middleware.rb:135:in `call_app'
+web-console (3.7.0) lib/web_console/middleware.rb:30:in `block in call'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `catch'
+web-console (3.7.0) lib/web_console/middleware.rb:20:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
+railties (5.0.7.2) lib/rails/rack/logger.rb:36:in `call_app'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `block in call'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `block in tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:26:in `tagged'
+activesupport (5.0.7.2) lib/active_support/tagged_logging.rb:69:in `tagged'
+railties (5.0.7.2) lib/rails/rack/logger.rb:24:in `call'
+sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:13:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/request_id.rb:24:in `call'
+rack (2.0.7) lib/rack/method_override.rb:22:in `call'
+rack (2.0.7) lib/rack/runtime.rb:22:in `call'
+activesupport (5.0.7.2) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/executor.rb:12:in `call'
+actionpack (5.0.7.2) lib/action_dispatch/middleware/static.rb:136:in `call'
+rack (2.0.7) lib/rack/sendfile.rb:111:in `call'
+railties (5.0.7.2) lib/rails/engine.rb:522:in `call'
+puma (3.12.1) lib/puma/configuration.rb:227:in `call'
+puma (3.12.1) lib/puma/server.rb:660:in `handle_request'
+puma (3.12.1) lib/puma/server.rb:474:in `process_client'
+puma (3.12.1) lib/puma/server.rb:334:in `block in run'
+puma (3.12.1) lib/puma/thread_pool.rb:135:in `block in spawn_thread'
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb
+  Rendering /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.text.erb
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/_trace.text.erb (0.6ms)
+  Rendered /Users/choisdavid/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/templates/rescues/routing_error.text.erb (28.5ms)
+Started GET "/groups/17/messages" for ::1 at 2020-01-16 16:52:01 +0900
+Processing by MessagesController#index as HTML
+  Parameters: {"group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering messages/index.html.haml within layouts/application
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT `groups`.* FROM `groups` INNER JOIN `group_users` ON `groups`.`id` = `group_users`.`group_id` WHERE `group_users`.`user_id` = 8[0m
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT  `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 ORDER BY `messages`.`id` DESC LIMIT 1[0m
+  Rendered shared/_side_bar.html.haml (7.0ms)
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` INNER JOIN `group_users` ON `users`.`id` = `group_users`.`user_id` WHERE `group_users`.`group_id` = 17[0m
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered collection of messages/_message.html.haml [3 times] (3.2ms)
+  Rendered messages/_main_chat.html.haml (9.3ms)
+  Rendered messages/index.html.haml within layouts/application (23.4ms)
+  Rendered layouts/_notifications.html.haml (1.5ms)
+Completed 200 OK in 58ms (Views: 50.3ms | ActiveRecord: 2.6ms)
+
+
+Started GET "/groups/17/api/messages?id=50" for ::1 at 2020-01-16 16:52:02 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"50", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 50)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 17ms (Views: 9.4ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/groups/17/api/messages?id=50" for ::1 at 2020-01-16 16:52:02 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"50", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 50)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 12ms (Views: 8.9ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/17/api/messages?id=50" for ::1 at 2020-01-16 16:52:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"50", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 50)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 20ms (Views: 14.0ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=50" for ::1 at 2020-01-16 16:52:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"50", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 50)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 16ms (Views: 9.7ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/groups/17/api/messages?id=50" for ::1 at 2020-01-16 16:52:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"50", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 50)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 13ms (Views: 8.4ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/17/api/messages?id=50" for ::1 at 2020-01-16 16:52:09 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"50", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 50)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 12ms (Views: 8.3ms | ActiveRecord: 0.6ms)
+
+
+Started POST "/groups/17/messages" for ::1 at 2020-01-16 16:52:15 +0900
+Processing by MessagesController#create as JSON
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"YVMVYHv+ddRZqOaHL9aTnJfF9FIs0GZ9tx/ofT+kzrCazM2McQiz82/WPeZAki8SztasvYCEhnOCF88xSK3vxg==", "message"=>{"content"=>"どうかな"}, "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  [1m[35m (0.3ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 LIMIT 1[0m
+  [1m[35mSQL (0.3ms)[0m  [1m[32mINSERT INTO `messages` (`content`, `group_id`, `user_id`, `created_at`, `updated_at`) VALUES ('どうかな', 17, 8, '2020-01-16 07:52:15', '2020-01-16 07:52:15')[0m
+  [1m[35m (0.7ms)[0m  [1m[35mCOMMIT[0m
+  Rendering messages/create.json.jbuilder
+  Rendered messages/create.json.jbuilder (0.6ms)
+Completed 200 OK in 20ms (Views: 8.4ms | ActiveRecord: 2.1ms)
+
+
+Started GET "/groups/17/api/messages?id=50" for ::1 at 2020-01-16 16:52:16 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"50", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 50)[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (3.7ms)
+Completed 200 OK in 22ms (Views: 16.1ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=50" for ::1 at 2020-01-16 16:52:16 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"50", "group_id"=>"17"}
+  [1m[36mUser Load (3.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 50)[0m
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (7.5ms)
+Completed 200 OK in 30ms (Views: 16.4ms | ActiveRecord: 7.6ms)
+
+
+Started GET "/groups/17/api/messages?id=51" for ::1 at 2020-01-16 16:52:16 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"51", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 51)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 14ms (Views: 9.9ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=51" for ::1 at 2020-01-16 16:52:16 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"51", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 51)[0m
+  Rendered api/messages/index.json.jbuilder (0.9ms)
+Completed 200 OK in 12ms (Views: 8.3ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/17/api/messages?id=51" for ::1 at 2020-01-16 16:52:23 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"51", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 51)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 22ms (Views: 16.4ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=51" for ::1 at 2020-01-16 16:52:23 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"51", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 51)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 20ms (Views: 13.9ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=51" for ::1 at 2020-01-16 16:52:23 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"51", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 51)[0m
+  Rendered api/messages/index.json.jbuilder (2.7ms)
+Completed 200 OK in 31ms (Views: 20.4ms | ActiveRecord: 4.5ms)
+
+
+Started GET "/groups/17/api/messages?id=51" for ::1 at 2020-01-16 16:52:23 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"51", "group_id"=>"17"}
+  [1m[36mUser Load (14.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (12.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 51)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 53ms (Views: 16.3ms | ActiveRecord: 27.2ms)
+
+
+Started POST "/groups/17/messages" for ::1 at 2020-01-16 16:52:27 +0900
+Processing by MessagesController#create as JSON
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"YVMVYHv+ddRZqOaHL9aTnJfF9FIs0GZ9tx/ofT+kzrCazM2McQiz82/WPeZAki8SztasvYCEhnOCF88xSK3vxg==", "message"=>{"content"=>"やったかな"}, "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 LIMIT 1[0m
+  [1m[35mSQL (0.2ms)[0m  [1m[32mINSERT INTO `messages` (`content`, `group_id`, `user_id`, `created_at`, `updated_at`) VALUES ('やったかな', 17, 8, '2020-01-16 07:52:27', '2020-01-16 07:52:27')[0m
+  [1m[35m (5.2ms)[0m  [1m[35mCOMMIT[0m
+  Rendering messages/create.json.jbuilder
+  Rendered messages/create.json.jbuilder (0.8ms)
+Completed 200 OK in 29ms (Views: 13.7ms | ActiveRecord: 6.1ms)
+
+
+Started GET "/groups/17/api/messages?id=51" for ::1 at 2020-01-16 16:52:30 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"51", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (14.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 51)[0m
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (17.7ms)
+Completed 200 OK in 32ms (Views: 12.4ms | ActiveRecord: 15.6ms)
+
+
+Started GET "/groups/17/api/messages?id=51" for ::1 at 2020-01-16 16:52:30 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"51", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 51)[0m
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (3.1ms)
+Completed 200 OK in 18ms (Views: 13.1ms | ActiveRecord: 1.3ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:52:30 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 14ms (Views: 9.6ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:52:30 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (0.9ms)
+Completed 200 OK in 12ms (Views: 8.4ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:52:37 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 13ms (Views: 9.0ms | ActiveRecord: 0.9ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:52:37 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 12ms (Views: 8.3ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:52:37 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 14ms (Views: 9.8ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:52:37 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (0.9ms)
+Completed 200 OK in 12ms (Views: 8.3ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:52:44 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 16ms (Views: 10.3ms | ActiveRecord: 0.9ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:52:44 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 13ms (Views: 8.9ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:52:44 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 15ms (Views: 10.3ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:52:44 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 17ms (Views: 8.7ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:52:51 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (2.3ms)
+Completed 200 OK in 23ms (Views: 14.3ms | ActiveRecord: 2.7ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:52:51 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (2.5ms)
+Completed 200 OK in 20ms (Views: 13.5ms | ActiveRecord: 1.4ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:52:51 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 21ms (Views: 13.1ms | ActiveRecord: 1.7ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:52:51 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 13ms (Views: 9.1ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:52:58 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (2.3ms)
+Completed 200 OK in 31ms (Views: 24.8ms | ActiveRecord: 1.3ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:52:58 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (2.8ms)
+Completed 200 OK in 34ms (Views: 21.0ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:52:58 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 15ms (Views: 10.0ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:52:58 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (0.9ms)
+Completed 200 OK in 12ms (Views: 8.3ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:06 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (2.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 26ms (Views: 15.2ms | ActiveRecord: 6.2ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:06 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.0ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.9ms)
+Completed 200 OK in 19ms (Views: 12.2ms | ActiveRecord: 1.7ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:06 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (3.9ms)
+Completed 200 OK in 24ms (Views: 16.1ms | ActiveRecord: 2.9ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:06 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 18ms (Views: 12.6ms | ActiveRecord: 0.9ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:12 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 20ms (Views: 11.4ms | ActiveRecord: 1.3ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:12 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (5.6ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (7.9ms)
+Completed 200 OK in 24ms (Views: 12.1ms | ActiveRecord: 6.5ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:13 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (3.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (1.1ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (2.7ms)
+Completed 200 OK in 25ms (Views: 14.1ms | ActiveRecord: 5.0ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:13 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (2.0ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (3.0ms)
+Completed 200 OK in 22ms (Views: 13.1ms | ActiveRecord: 3.7ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:19 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 21ms (Views: 14.4ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:19 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 13ms (Views: 8.9ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:19 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.7ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 20ms (Views: 11.3ms | ActiveRecord: 2.6ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:19 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 13ms (Views: 9.2ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:26 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (2.3ms)
+Completed 200 OK in 24ms (Views: 15.7ms | ActiveRecord: 1.5ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:26 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (6.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (8.1ms)
+Completed 200 OK in 28ms (Views: 16.5ms | ActiveRecord: 7.1ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:26 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 15ms (Views: 11.5ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:26 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 13ms (Views: 9.0ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:33 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 18ms (Views: 11.2ms | ActiveRecord: 1.3ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:33 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 12ms (Views: 8.4ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:33 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (2.2ms)
+Completed 200 OK in 14ms (Views: 10.0ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:33 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 12ms (Views: 8.2ms | ActiveRecord: 0.5ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:40 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 18ms (Views: 10.1ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:40 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 14ms (Views: 8.8ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:40 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 15ms (Views: 9.8ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:40 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (0.9ms)
+Completed 200 OK in 12ms (Views: 8.3ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:47 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 18ms (Views: 12.7ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:47 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 16ms (Views: 9.4ms | ActiveRecord: 1.4ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:47 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 17ms (Views: 12.0ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:47 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 15ms (Views: 10.2ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:54 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 19ms (Views: 14.1ms | ActiveRecord: 0.9ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:54 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 16ms (Views: 9.5ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:54 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 15ms (Views: 10.1ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:53:54 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 12ms (Views: 8.4ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:01 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 22ms (Views: 13.7ms | ActiveRecord: 2.7ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:01 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 18ms (Views: 12.0ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:01 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 16ms (Views: 10.0ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:01 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 13ms (Views: 8.6ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:08 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (2.6ms)
+Completed 200 OK in 20ms (Views: 13.9ms | ActiveRecord: 1.2ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:08 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 19ms (Views: 12.9ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:08 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 14ms (Views: 9.9ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:08 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (0.9ms)
+Completed 200 OK in 12ms (Views: 8.2ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:15 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 20ms (Views: 13.7ms | ActiveRecord: 0.9ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:15 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 15ms (Views: 10.0ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:15 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 19ms (Views: 12.1ms | ActiveRecord: 1.9ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:15 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.1ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 13ms (Views: 9.6ms | ActiveRecord: 0.6ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:22 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.7ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.7ms)
+Completed 200 OK in 15ms (Views: 10.5ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:22 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 16ms (Views: 11.2ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:22 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.4ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 18ms (Views: 10.6ms | ActiveRecord: 2.1ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:22 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.6ms)
+Completed 200 OK in 16ms (Views: 10.9ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:29 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (2.2ms)
+Completed 200 OK in 19ms (Views: 12.7ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:29 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 17ms (Views: 11.5ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:29 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 16ms (Views: 11.3ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:29 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 16ms (Views: 11.2ms | ActiveRecord: 0.9ms)
+
+
+Started POST "/groups/17/messages" for ::1 at 2020-01-16 16:54:32 +0900
+Processing by MessagesController#create as JSON
+  Parameters: {"utf8"=>"✓", "authenticity_token"=>"YVMVYHv+ddRZqOaHL9aTnJfF9FIs0GZ9tx/ofT+kzrCazM2McQiz82/WPeZAki8SztasvYCEhnOCF88xSK3vxg==", "message"=>{"content"=>"それでは、コードレビューにかけるぞ"}, "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  [1m[35m (0.1ms)[0m  [1m[35mBEGIN[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 LIMIT 1[0m
+  [1m[35mSQL (0.3ms)[0m  [1m[32mINSERT INTO `messages` (`content`, `group_id`, `user_id`, `created_at`, `updated_at`) VALUES ('それでは、コードレビューにかけるぞ', 17, 8, '2020-01-16 07:54:32', '2020-01-16 07:54:32')[0m
+  [1m[35m (1.9ms)[0m  [1m[35mCOMMIT[0m
+  Rendering messages/create.json.jbuilder
+  Rendered messages/create.json.jbuilder (0.6ms)
+Completed 200 OK in 21ms (Views: 10.0ms | ActiveRecord: 2.9ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:36 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (3.1ms)
+Completed 200 OK in 17ms (Views: 11.8ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=52" for ::1 at 2020-01-16 16:54:36 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"52", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 52)[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT `users`.* FROM `users` WHERE `users`.`id` = 8[0m
+  Rendered api/messages/index.json.jbuilder (2.5ms)
+Completed 200 OK in 19ms (Views: 13.0ms | ActiveRecord: 1.1ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 16:54:36 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (1.0ms)
+Completed 200 OK in 15ms (Views: 10.2ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 16:54:36 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (1.3ms)
+Completed 200 OK in 12ms (Views: 8.7ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 16:54:43 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 15ms (Views: 10.3ms | ActiveRecord: 0.7ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 16:54:43 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 17ms (Views: 12.9ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 16:54:43 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 19ms (Views: 12.5ms | ActiveRecord: 0.8ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 16:54:43 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.2ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (1.1ms)
+Completed 200 OK in 18ms (Views: 12.1ms | ActiveRecord: 0.9ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 16:54:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (4.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (6.0ms)
+Completed 200 OK in 39ms (Views: 28.4ms | ActiveRecord: 5.0ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 16:54:50 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.5ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (2.1ms)
+Completed 200 OK in 22ms (Views: 16.6ms | ActiveRecord: 1.0ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 16:54:51 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (4.8ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.2ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (1.5ms)
+Completed 200 OK in 26ms (Views: 15.2ms | ActiveRecord: 6.4ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 16:54:51 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (2.2ms)
+Completed 200 OK in 27ms (Views: 19.2ms | ActiveRecord: 2.2ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 16:54:58 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (6.2ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (3.5ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.4ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (1.4ms)
+Completed 200 OK in 29ms (Views: 14.7ms | ActiveRecord: 10.1ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 16:54:58 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (0.3ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.3ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (1.2ms)
+Completed 200 OK in 19ms (Views: 14.0ms | ActiveRecord: 0.9ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 16:54:58 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (1.9ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (0.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (2.3ms)
+Completed 200 OK in 22ms (Views: 13.6ms | ActiveRecord: 3.2ms)
+
+
+Started GET "/groups/17/api/messages?id=53" for ::1 at 2020-01-16 16:54:58 +0900
+Processing by Api::MessagesController#index as JSON
+  Parameters: {"id"=>"53", "group_id"=>"17"}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT  `users`.* FROM `users` WHERE `users`.`id` = 8 ORDER BY `users`.`id` ASC LIMIT 1[0m
+  [1m[36mGroup Load (5.6ms)[0m  [1m[34mSELECT  `groups`.* FROM `groups` WHERE `groups`.`id` = 17 LIMIT 1[0m
+  Rendering api/messages/index.json.jbuilder
+  [1m[36mMessage Load (3.8ms)[0m  [1m[34mSELECT `messages`.* FROM `messages` WHERE `messages`.`group_id` = 17 AND (id > 53)[0m
+  Rendered api/messages/index.json.jbuilder (5.1ms)
+Completed 200 OK in 31ms (Views: 15.3ms | ActiveRecord: 10.1ms)
+
+


### PR DESCRIPTION
＃what
以下の機能を順次実装する
①何秒かおきに、JavaScriptを使ってブラウザに表示されているメッセージのうち最も新しいもののidをリクエストとして送る
②Railsのコントローラのアクションにてデータベースに保存されている最新のメッセージのidと①のidを比較し、①のidよりも大きいidを持つメッセージたちをレスポンスする
③JavaScriptを使って、レスポンスに含まれるメッセージたちをメッセージ一覧の最後に追加する
＃why
投稿者以外のユーザーの利便性を向上させるため